### PR TITLE
issue/93 - Accordion width updated and centered in the parent

### DIFF
--- a/src/components/Accordion/Accordion.module.scss
+++ b/src/components/Accordion/Accordion.module.scss
@@ -1,7 +1,7 @@
 .container {
   border-radius: 10px;
   margin-bottom: 1rem;
-  min-width: 800px;
+  width: 750px;
 
   @media (max-width: 767px) {
     min-width: 300px;

--- a/src/styles/tasks.module.scss
+++ b/src/styles/tasks.module.scss
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
+  align-items: center;
   flex-wrap: nowrap;
   text-align: center;
 }


### PR DESCRIPTION
parent - task_container.

fix #93 

On changing the maximum width to 750px it will look like this : 
![image](https://user-images.githubusercontent.com/10326494/114281270-1c27bd80-9a5b-11eb-9ea8-957da6208829.png)

After aligning to center it looks better, so updating with the same
![image](https://user-images.githubusercontent.com/10326494/114281439-04046e00-9a5c-11eb-876d-dace8862e4b9.png)

Do comment with the same incase of any issues