### PR TITLE
fix for navBar style in mobile devices

### DIFF
--- a/src/components/navBar/navBar.module.scss
+++ b/src/components/navBar/navBar.module.scss
@@ -4,29 +4,32 @@ $thickness: 3px;
 .navBar {
   display: flex;
   width: 100%;
-  background-color: hsl(246, 76%, 29%);
+  background-color: #1d1283;
   align-items: center;
   overflow: hidden;
   flex-wrap: wrap;
 
-    a{
-      display: block;
-      color: #ffffff;
-      font-weight: bolder;
-      text-align: center;
-      padding: 35px 2*($offset+$thickness)-1;
-      text-decoration: none;
-    }
-    a:hover {
+  a {
+    display: block;
+    color: #ffffff;
+    font-weight: bolder;
+    text-align: center;
+    padding: 35px 2*($offset+$thickness)-1;
+    text-decoration: none;
+
+    &:hover {
       color: #87d870;
     }
-    .active{
-      color: #87d870;
-      text-decoration: underline;
-      text-decoration-thickness: $thickness;
-      text-underline-offset: $offset;
-    }
-    .logo{
-      padding: ($offset+$thickness)+7;
-    }
+  }
+
+  .active {
+    color: #87d870;
+    text-decoration: underline;
+    text-decoration-thickness: $thickness;
+    text-underline-offset: $offset;
+  }
+
+  .logo {
+    padding: ($offset+$thickness)+7;
+  }
 }


### PR DESCRIPTION
closes #213 
iPhone X view before changes:
![image](https://user-images.githubusercontent.com/56400876/140515046-b0f511cc-f55e-45f3-84aa-e84b73b8fb66.png)


iPhone X view after changes:
![image](https://user-images.githubusercontent.com/56400876/140515269-925d6835-371a-40c8-afd9-467d21ff9955.png)

Samsung Galaxy fold view before changes:
![image](https://user-images.githubusercontent.com/56400876/140515368-5c378e0f-8b79-4ac0-804c-6a75e113da57.png)


Samsung Galaxy fold view after changes:
![image](https://user-images.githubusercontent.com/56400876/140515243-c76d38bc-a19d-4ad2-9bc2-d7158161f1fd.png)

Note:
The rest of the devices were aligned as expected.

Fix for all screens to vertically centre the text.
Before changes:
![image](https://user-images.githubusercontent.com/56400876/140515626-01bfb8c7-2471-4d8e-9144-2229dff969b7.png)

After changes:
![image](https://user-images.githubusercontent.com/56400876/140515596-ad43b665-1d17-47cf-8144-19dbcc3822b3.png)
