### PR TITLE
Infinite Image fetch fixed

### DIFF
--- a/src/components/idleMembers/card/index.tsx
+++ b/src/components/idleMembers/card/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 }
 
 const Card: FC<Props> = ({ idleMemberUserName }) => {
-  const [isError, setIsError] = useState(false);
+  const [isImageAvailable, setIsImageAvailable] = useState(false);
 
   const assigneeProfilePic = (name: string) => `${IMAGE_URL}/${name}/img.png`;
   const getMemberDetails = (name: string) => {
@@ -18,7 +18,7 @@ const Card: FC<Props> = ({ idleMemberUserName }) => {
     if (newWindow) newWindow.opener = null;
   };
   const assigneeImageOnError = (e: SyntheticEvent<HTMLImageElement>) => {
-    setIsError(true);
+    setIsImageAvailable(true);
   };
   return (
     <div
@@ -28,7 +28,7 @@ const Card: FC<Props> = ({ idleMemberUserName }) => {
       aria-hidden="true"
     >
       <Image
-        src={isError ? `/${DUMMY_PROFILE}` : assigneeProfilePic(idleMemberUserName)}
+        src={isImageAvailable ? `/${DUMMY_PROFILE}` : assigneeProfilePic(idleMemberUserName)}
         alt={idleMemberUserName}
         onError={assigneeImageOnError}
         width={150}

--- a/src/components/idleMembers/card/index.tsx
+++ b/src/components/idleMembers/card/index.tsx
@@ -1,4 +1,4 @@
-import { FC, SyntheticEvent } from 'react';
+import { FC, SyntheticEvent, useState } from 'react';
 import Image from 'next/image';
 import classNames from '@/components/idleMembers/card/card.module.scss';
 import { DUMMY_PROFILE } from '@/components/constants/display-sections.js';
@@ -10,13 +10,15 @@ type Props = {
 }
 
 const Card: FC<Props> = ({ idleMemberUserName }) => {
+  const [isError, setIsError] = useState(false);
+
   const assigneeProfilePic = (name: string) => `${IMAGE_URL}/${name}/img.png`;
   const getMemberDetails = (name: string) => {
     const newWindow = window.open(`https://members.realdevsquad.com/${name}`, '_blank', ' noopener ,norefferrer');
     if (newWindow) newWindow.opener = null;
   };
   const assigneeImageOnError = (e: SyntheticEvent<HTMLImageElement>) => {
-    e.currentTarget.src = DUMMY_PROFILE;
+    setIsError(true);
   };
   return (
     <div
@@ -26,7 +28,7 @@ const Card: FC<Props> = ({ idleMemberUserName }) => {
       aria-hidden="true"
     >
       <Image
-        src={assigneeProfilePic(idleMemberUserName)}
+        src={isError ? `/${DUMMY_PROFILE}` : assigneeProfilePic(idleMemberUserName)}
         alt={idleMemberUserName}
         onError={assigneeImageOnError}
         width={150}


### PR DESCRIPTION
RFC - #304

## What was happening Before
Whenever there is an error in getting the image of a user on the `idle-members` page it used to re-fetch infinitely as the error handling was done in a `non-React way` and therefore was not working.

## What I did do and How is it working?
I just simply added a state to the component so that If It finds any error, it will re-render with a fetching fallback image for error handling.