### PR TITLE
refactoring and filtering options in edit mode

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_BASE_URL='https://staging-api.realdevsquad.com'
+NEXT_PUBLIC_BASE_URL='http://localhost:4000'
 NEXT_PUBLIC_GITHUB_IMAGE_URL='https://raw.githubusercontent.com/Real-Dev-Squad/website-static/main/members'
-NEXT_PUBLIC_API_MOCKING='ON'
+NEXT_PUBLIC_API_MOCKING='OFF'
 

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_BASE_URL='http://localhost:4000'
+NEXT_PUBLIC_BASE_URL='https://staging-api.realdevsquad.com'
 NEXT_PUBLIC_GITHUB_IMAGE_URL='https://raw.githubusercontent.com/Real-Dev-Squad/website-static/main/members'
-NEXT_PUBLIC_API_MOCKING='OFF'
+NEXT_PUBLIC_API_MOCKING='ON'
 

--- a/src/components/tasks/card/TaskTagEdit.tsx
+++ b/src/components/tasks/card/TaskTagEdit.tsx
@@ -66,10 +66,10 @@ const TaskTagEdit = ({ updateTaskTagLevel,taskTagLevel }: TaskTagPropsType) => {
     const { ERROR } = ToastTypes
     let tagOptions = taskTags;
     // filtering out tag options: if a skill is present then to remove it from the options
-    taskTagLevel
+    (taskTagLevel && taskTags)
     &&
-    taskTags?.forEach((tag) => {
-        taskTagLevel?.forEach(item => {
+    taskTags.forEach((tag) => {
+        taskTagLevel.forEach(item => {
             if(item.tagName === tag.name){
                 tagOptions = tagOptions && tagOptions.filter((tag) => tag.name !== item.tagName)
             }

--- a/src/components/tasks/card/TaskTagEdit.tsx
+++ b/src/components/tasks/card/TaskTagEdit.tsx
@@ -16,10 +16,10 @@ type SelectComponentPropsType = {
     options: levelType[] | tagType[]
     name: 'tags' | 'levels'
     defaultOption: '--new tag--' | '--new level--'
-    setNewValueOnChange: React.Dispatch<React.SetStateAction<string | undefined>>
+    setNewValueOnChange: React.Dispatch<React.SetStateAction<any>>
     id: string
     label: string
-    value: string | undefined
+    value: string | number | undefined
 }
 
 
@@ -45,9 +45,9 @@ return (
             <option disabled selected>{defaultOption}</option>
             {
                 options?.map(option => (
-                    <option key={option.name} value={option.name}>
+                    <option key={option.id} value={option.name}>
                         {name === "levels" 
-                            ? `Level - ${option.name}`
+                            ? `Level - ${(option as levelType).value}`
                             : option.name
                         }
                     </option>
@@ -60,23 +60,28 @@ return (
 }
 
 const TaskTagEdit = ({ updateTaskTagLevel,taskTagLevel }: TaskTagPropsType) => {
-    const [newLevelValue, setNewLevelValue] = useState<string>()
+    const [newLevelValue, setNewLevelValue] = useState<number>()
     const [newTagValue, setNewTagValue] = useState<string>()
-    const { taskLevels, taskTags } = useTasksContext()
+    const { taskLevels: levelOptions, taskTags } = useTasksContext()
     const { ERROR } = ToastTypes
+    let tagOptions = taskTags;
+    // filtering out tag options: if a skill is present then to remove it from the options
+    taskTagLevel
+    &&
+    taskTags?.forEach((tag) => {
+        taskTagLevel?.forEach(item => {
+            if(item.tagName === tag.name){
+                tagOptions = tagOptions && tagOptions.filter((tag) => tag.name !== item.tagName)
+            }
+        })
+    })
     
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        const tagToAdd = taskTags?.find(tag => tag.name === newTagValue)
-        const levelToAdd = taskLevels?.find(level => level.name === newLevelValue)
-        const isTagExists = taskTagLevel?.find((tagLevel) => {
-           return tagLevel.tagId === tagToAdd?.id
-        })
+        const tagToAdd = tagOptions?.find(tag => tag.name === newTagValue)
+        const levelToAdd = levelOptions?.find(level => level.value == newLevelValue)
+
         if(newTagValue && newLevelValue) {
-        if(isTagExists){
-            toast(ERROR,`Tag with Level already exists`);
-            return;
-        }
             if(levelToAdd && tagToAdd){
                 const taskItemToUpdate: taskItem = {
                     levelId: levelToAdd.id,
@@ -84,7 +89,7 @@ const TaskTagEdit = ({ updateTaskTagLevel,taskTagLevel }: TaskTagPropsType) => {
                     tagId: tagToAdd.id,
                     tagName: tagToAdd.name,
                     tagType: "SKILL",
-                    levelNumber: levelToAdd.levelNumber
+                    levelValue: levelToAdd.value
                 }
                 updateTaskTagLevel(taskItemToUpdate, 'post')
             } else {
@@ -94,7 +99,7 @@ const TaskTagEdit = ({ updateTaskTagLevel,taskTagLevel }: TaskTagPropsType) => {
             toast(ERROR, `Tag and Level values both needed`)
         }
     }
-    if (taskLevels && taskTags){
+    if (levelOptions && tagOptions){
     return(
         <>
                 <form className={classNames.addTaskTagLevel} onSubmit={handleSubmit}>
@@ -104,7 +109,7 @@ const TaskTagEdit = ({ updateTaskTagLevel,taskTagLevel }: TaskTagPropsType) => {
                     label="select tag"
                     value={newTagValue}
                     name="tags"
-                    options={taskTags}
+                    options={tagOptions}
                     setNewValueOnChange={setNewTagValue}
                 />
                 <SelectComponent 
@@ -113,10 +118,10 @@ const TaskTagEdit = ({ updateTaskTagLevel,taskTagLevel }: TaskTagPropsType) => {
                     label="select level"
                     value={newLevelValue}
                     name="levels"
-                    options={taskLevels}
+                    options={levelOptions}
                     setNewValueOnChange={setNewLevelValue}
                 />
-                <button>Add</button>
+                <button className={classNames.addTagLevelBtn}>Add</button>
             </form>
         </>)
     }

--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -143,8 +143,10 @@ $taskTagLevelBg: hsla(225, 73%, 57%,0.5);
   padding: 0.35em;
   border-radius: 20px;
   border: 2px solid $taskTagLevelBorder;
+  font-size: 0.85em;
+  font-weight: 500;
   small{
-    font-size: .75em;
+    font-size: 0.75em;
   }
 
   .removeTaskTagLevelBtn{
@@ -201,6 +203,10 @@ $taskTagLevelBg: hsla(225, 73%, 57%,0.5);
     clip-path: polygon(100% 0%, 0 0%, 50% 100%);
     justify-self: end;
   }
+}
+
+.addTagLevelBtn {
+  cursor: pointer;
 }
 
 /* loading spinner  */

--- a/src/components/tasks/card/index.tsx
+++ b/src/components/tasks/card/index.tsx
@@ -279,7 +279,7 @@ const Card: FC<Props> = ({
             <div className={classNames.taskTagLevelContainer}>
             {
               taskTagLevel?.map((item) => (
-                <span key={item.tagId} className={classNames.taskTagLevel}>{item.tagName} <small><b>LVL:{item.levelNumber}</b></small>{
+                <span key={item.tagId} className={classNames.taskTagLevel}>{item.tagName} <small><b>LVL:{item.levelValue}</b></small>{
                   shouldEdit && isUserAuthorized &&
                   (
                     <span>

--- a/src/context/tasks.context.tsx
+++ b/src/context/tasks.context.tsx
@@ -35,11 +35,7 @@ export const TasksProvider = ({children }: { children: React.ReactNode })=> {
                 url: ALL_LEVELS_URL
             })
             const { data } = await requestPromise;
-            const sortedTaskLevels = (data.levels).sort((a: levelType,b: levelType) => {
-                if(parseInt(a.name) < parseInt(b.name)) return -1;
-                if(parseInt(a.name) > parseInt(b.name)) return 1;
-                return 0
-            })
+            const sortedTaskLevels = (data.levels).sort((a: levelType,b: levelType) => a.value < b.value ? -1 : 1 )
             setTaskLevels(sortedTaskLevels)
            })();
     },[])

--- a/src/interfaces/level.type.ts
+++ b/src/interfaces/level.type.ts
@@ -2,7 +2,7 @@ type levelType = {
     createdBy: string
     date: { _seconds: string, _nanoseconds: string }
     id: string
-    levelNumber: number
+    value: number
     name: string
 }
 

--- a/src/interfaces/taskItem.type.ts
+++ b/src/interfaces/taskItem.type.ts
@@ -3,7 +3,7 @@ type taskItem = {
     itemType?: 'TASK'
     levelId: string
     levelName: string
-    levelNumber: number
+    levelValue: number
     tagId: string
     tagName: string
     tagType: 'SKILL'


### PR DESCRIPTION
## Change
- Refactoring the level and item keys
- Filtering out tag options if it's already present on the task (In edit mode of tasks page on status site)
![Screenshot (16)](https://user-images.githubusercontent.com/33935339/206095666-c88bb9e3-fa75-4044-983b-617d6610c48a.png)

Fig: System design is not present in the below options as it was already present on the task.
