### PR TITLE
See More For Tasks

### DIFF
--- a/__tests__/Unit/Components/TaskList.test.tsx
+++ b/__tests__/Unit/Components/TaskList.test.tsx
@@ -1,0 +1,72 @@
+import TaskList from "@/components/tasks/TaskList/TaskList";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const TASK = {
+  id: "firestoreDocumentId123",
+  lossRate: {
+    dinero: 10,
+    neelam: 5,
+  },
+  links: ["https://realdevsquad.com/learn-site"],
+  completionAward: {
+    dinero: 110,
+    neelam: 10,
+  },
+  dependsOn: [],
+  assignee: "shmbajaj",
+  startedOn: "1618790400",
+  isNoteworthy: true,
+  title: "Testing and Determinsitic State",
+  purpose: "string",
+  percentCompleted: 0,
+  endsOn: "1618790400",
+  status: "progress",
+  featureUrl: "progress",
+  type: "feature",
+  createdBy: "shmbajaj",
+};
+const tasks = Array.from({ length: 10 }).map((_, index) => ({ ...TASK, id: TASK.id + index }));
+
+describe("TaskList", function () {
+  it("Should render TaskList", function () {
+    render(<TaskList tasks={tasks} />);
+
+    const task = screen.queryByText(TASK.title);
+    const _tasks = screen.queryAllByText(TASK.title);
+
+    expect(task).toBeInTheDocument();
+    expect(_tasks).toHaveLength(10);
+  });
+
+  it("Should render see more button", function () {
+    render(<TaskList tasks={tasks} hasLimit={true} />);
+
+    const seeMore = screen.getByRole("button", { name: /see more/i });
+
+    expect(seeMore).toBeInTheDocument();
+  });
+
+  it("Should render 3 tasks intially and then load and render more 5 tasks after see more button click event", function () {
+    render(<TaskList tasks={tasks} hasLimit={true} />);
+
+    const _tasks = screen.queryAllByText(TASK.title);
+    const seeMore = screen.getByRole("button", { name: /see more/i });
+
+    expect(_tasks).toHaveLength(3);
+    fireEvent.click(seeMore);
+    expect(_tasks).toHaveLength(8);
+  });
+
+  it("Shouldn't render see more button after all tasks load and render", function () {
+    render(<TaskList tasks={tasks} hasLimit={true} />);
+
+    const _tasks = screen.queryAllByText(TASK.title);
+    const seeMore = screen.getByRole("button", { name: /see more/i });
+
+    expect(_tasks).toHaveLength(3);
+    fireEvent.click(seeMore);
+    fireEvent.click(seeMore);
+    expect(_tasks).toHaveLength(10);
+    expect(seeMore).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/Unit/Components/TaskList.test.tsx
+++ b/__tests__/Unit/Components/TaskList.test.tsx
@@ -31,11 +31,11 @@ describe("TaskList", function () {
   it("Should render TaskList", function () {
     render(<TaskList tasks={tasks} />);
 
-    const task = screen.queryByText(TASK.title);
     const _tasks = screen.queryAllByText(TASK.title);
 
-    expect(task).toBeInTheDocument();
     expect(_tasks).toHaveLength(10);
+    expect(_tasks[0]).toBeInTheDocument();
+    expect(_tasks[0]).toHaveTextContent(TASK.title)
   });
 
   it("Should render see more button", function () {
@@ -46,7 +46,7 @@ describe("TaskList", function () {
     expect(seeMore).toBeInTheDocument();
   });
 
-  it("Should render 3 tasks intially and then load and render more 5 tasks after see more button click event", function () {
+  it("Should render 3 tasks intially and then render more 5 tasks after click event", function () {
     render(<TaskList tasks={tasks} hasLimit={true} />);
 
     const _tasks = screen.queryAllByText(TASK.title);
@@ -54,10 +54,10 @@ describe("TaskList", function () {
 
     expect(_tasks).toHaveLength(3);
     fireEvent.click(seeMore);
-    expect(_tasks).toHaveLength(8);
+    expect(screen.queryAllByText(TASK.title)).toHaveLength(8);
   });
 
-  it("Shouldn't render see more button after all tasks load and render", function () {
+  it("Shouldn't render see more button after all tasks are loaded and rendered", function () {
     render(<TaskList tasks={tasks} hasLimit={true} />);
 
     const _tasks = screen.queryAllByText(TASK.title);
@@ -66,7 +66,7 @@ describe("TaskList", function () {
     expect(_tasks).toHaveLength(3);
     fireEvent.click(seeMore);
     fireEvent.click(seeMore);
-    expect(_tasks).toHaveLength(10);
+    expect(screen.queryAllByText(TASK.title)).toHaveLength(10);
     expect(seeMore).not.toBeInTheDocument();
   });
 });

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -16,9 +16,19 @@ type TaksListProps = {
   updateCardContent?: (id: string, cardDetails: task) => void;
 };
 
-function getFilteredTasks({hasLimit, tasksLimit, tasks}: {hasLimit: boolean, tasksLimit: number, tasks: task[]}) {
-  if (!hasLimit) return tasks;
-  return tasks.slice(0, tasksLimit);
+type FilterTasksProps = {
+  hasLimit?: boolean
+  tasksLimit: number
+  tasks: task[]
+}
+
+function getFilteredTasks({
+  hasLimit,
+  tasksLimit,
+  tasks,
+}: FilterTasksProps) {
+  if (!hasLimit) return tasks
+  return tasks.slice(0, tasksLimit)
 }
 
 export default function TaskList({

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -1,9 +1,13 @@
-import beautifyTaskStatus from "@/helperFunctions/beautifyTaskStatus";
-import task from "@/interfaces/task.type";
-import { useState } from "react";
-import Card from "../card";
-import styles from "../card/card.module.scss";
-import {SEE_MORE, INITIAL_TASKS_LIMIT, ADD_MORE_TASKS_LIMIT} from "../constants";
+import { useState } from 'react'
+import Card from '../card'
+import task from '@/interfaces/task.type'
+import beautifyTaskStatus from '@/helperFunctions/beautifyTaskStatus'
+import {
+  SEE_MORE,
+  INITIAL_TASKS_LIMIT,
+  ADD_MORE_TASKS_LIMIT,
+} from '../constants'
+import styles from '../card/card.module.scss'
 
 type TaksListProps = {
   tasks: task[];

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -3,6 +3,7 @@ import task from "@/interfaces/task.type";
 import { useState } from "react";
 import Card from "../card";
 import styles from "../card/card.module.scss";
+import {SEE_MORE, INITIAL_TASKS_LIMIT, ADD_MORE_TASKS_LIMIT} from "../constants";
 
 type TaksListProps = {
   tasks: task[];
@@ -11,24 +12,25 @@ type TaksListProps = {
   updateCardContent?: (id: string, cardDetails: task) => void;
 };
 
+function getFilteredTasks({hasLimit, tasksLimit, tasks}: {hasLimit: boolean, tasksLimit: number, tasks: task[]}) {
+  if (!hasLimit) return tasks;
+  return tasks.slice(0, tasksLimit);
+}
+
 export default function TaskList({
   tasks,
   updateCardContent,
   isEditable = false,
   hasLimit = false,
 }: TaksListProps) {
-  const initialTasksLimit = hasLimit ? 3 : tasks.length;
+  const initialTasksLimit = hasLimit ? INITIAL_TASKS_LIMIT : tasks.length;
   const beautifiedTasks = beautifyTaskStatus(tasks);
   const [tasksLimit, setTasksLimit] = useState<number>(initialTasksLimit);
-  const filteredTasks = getFilteredTasks();
-  function getFilteredTasks() {
-    if (!hasLimit) return beautifiedTasks;
-    return beautifiedTasks.slice(0, tasksLimit);
-  }
+  const filteredTasks = getFilteredTasks({tasks: beautifiedTasks, hasLimit, tasksLimit});
   function onSeeMoreTasksHandler() {
-    setTasksLimit((prevLimit) => prevLimit + 5);
+    setTasksLimit((prevLimit) => prevLimit + ADD_MORE_TASKS_LIMIT);
   }
-
+  
   return (
     <>
       {filteredTasks.map((item: task) => (
@@ -47,7 +49,7 @@ export default function TaskList({
           onClick={onSeeMoreTasksHandler}
           className={styles.seeMoreTasks}
         >
-          See More
+          {SEE_MORE}
         </button>
       )}
     </>

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -1,0 +1,34 @@
+import beautifyTaskStatus from "@/helperFunctions/beautifyTaskStatus";
+import task from "@/interfaces/task.type";
+import Card from "../card";
+
+type TaksListProps = {
+  tasks: task[];
+  isEditable?: boolean;
+  hasLimit?: boolean;
+  updateCardContent?: (id: string, cardDetails: task) => void;
+};
+
+export default function TaskList({
+  tasks,
+  updateCardContent,
+  isEditable = false,
+  hasLimit=false,
+}: TaksListProps) {
+  const beautifiedTasks = beautifyTaskStatus(tasks);
+
+  return (
+    <>
+    {beautifiedTasks.map((item: task) => (
+    <Card
+      content={item}
+      key={item.id}
+      shouldEdit={isEditable}
+      onContentChange={async (id: string, newDetails: any) =>
+        isEditable && updateCardContent?.(id, newDetails)
+      }
+    />
+  ))}
+    </>
+  )
+}

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -2,6 +2,7 @@ import beautifyTaskStatus from "@/helperFunctions/beautifyTaskStatus";
 import task from "@/interfaces/task.type";
 import { useState } from "react";
 import Card from "../card";
+import styles from "../card/card.module.scss";
 
 type TaksListProps = {
   tasks: task[];
@@ -14,35 +15,41 @@ export default function TaskList({
   tasks,
   updateCardContent,
   isEditable = false,
-  hasLimit=false,
+  hasLimit = false,
 }: TaksListProps) {
   const initialTasksLimit = hasLimit ? 3 : tasks.length;
   const beautifiedTasks = beautifyTaskStatus(tasks);
   const [tasksLimit, setTasksLimit] = useState<number>(initialTasksLimit);
   const filteredTasks = getFilteredTasks();
-  function getFilteredTasks(){
-    if(!hasLimit) return beautifiedTasks;
-    return beautifiedTasks.slice(0 , tasksLimit);
+  function getFilteredTasks() {
+    if (!hasLimit) return beautifiedTasks;
+    return beautifiedTasks.slice(0, tasksLimit);
   }
-  function onSeeMoreTasksHandler(){
-      setTasksLimit(prevLimit => prevLimit + 5);
+  function onSeeMoreTasksHandler() {
+    setTasksLimit((prevLimit) => prevLimit + 5);
   }
 
   return (
     <>
-    {filteredTasks.map((item: task) => (
-    <Card
-      content={item}
-      key={item.id}
-      shouldEdit={isEditable}
-      onContentChange={async (id: string, newDetails: any) =>
-        isEditable && updateCardContent?.(id, newDetails)
-      }
-    />
-  ))}
-  {
-    hasLimit && filteredTasks.length !=  beautifiedTasks.length && <button type="button" onClick={onSeeMoreTasksHandler}>See More</button>
-  }
+      {filteredTasks.map((item: task) => (
+        <Card
+          content={item}
+          key={item.id}
+          shouldEdit={isEditable}
+          onContentChange={async (id: string, newDetails: any) =>
+            isEditable && updateCardContent?.(id, newDetails)
+          }
+        />
+      ))}
+      {hasLimit && filteredTasks.length != beautifiedTasks.length && (
+        <button
+          type="button"
+          onClick={onSeeMoreTasksHandler}
+          className={styles.seeMoreTasks}
+        >
+          See More
+        </button>
+      )}
     </>
-  )
+  );
 }

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -34,6 +34,10 @@ export default function TaskList({
   function onSeeMoreTasksHandler() {
     setTasksLimit((prevLimit) => prevLimit + ADD_MORE_TASKS_LIMIT);
   }
+  async function onContentChangeHandler(id: string, cardDetails: any){
+    if(!isEditable || !updateCardContent) return;
+    updateCardContent(id, cardDetails);
+  }
   
   return (
     <>
@@ -42,9 +46,7 @@ export default function TaskList({
           content={item}
           key={item.id}
           shouldEdit={isEditable}
-          onContentChange={async (id: string, newDetails: any) =>
-            isEditable && updateCardContent?.(id, newDetails)
-          }
+          onContentChange={onContentChangeHandler}
         />
       ))}
       {hasLimit && filteredTasks.length != beautifiedTasks.length && (

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -1,5 +1,6 @@
 import beautifyTaskStatus from "@/helperFunctions/beautifyTaskStatus";
 import task from "@/interfaces/task.type";
+import { useState } from "react";
 import Card from "../card";
 
 type TaksListProps = {
@@ -15,11 +16,21 @@ export default function TaskList({
   isEditable = false,
   hasLimit=false,
 }: TaksListProps) {
+  const initialTasksLimit = hasLimit ? 3 : tasks.length;
   const beautifiedTasks = beautifyTaskStatus(tasks);
+  const [tasksLimit, setTasksLimit] = useState<number>(initialTasksLimit);
+  const filteredTasks = getFilteredTasks();
+  function getFilteredTasks(){
+    if(!hasLimit) return beautifiedTasks;
+    return beautifiedTasks.slice(0 , tasksLimit);
+  }
+  function onSeeMoreTasksHandler(){
+      setTasksLimit(prevLimit => prevLimit + 5);
+  }
 
   return (
     <>
-    {beautifiedTasks.map((item: task) => (
+    {filteredTasks.map((item: task) => (
     <Card
       content={item}
       key={item.id}
@@ -29,6 +40,9 @@ export default function TaskList({
       }
     />
   ))}
+  {
+    hasLimit && filteredTasks.length !=  beautifiedTasks.length && <button type="button" onClick={onSeeMoreTasksHandler}>See More</button>
+  }
     </>
   )
 }

--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -209,6 +209,24 @@ $taskTagLevelBg: hsla(225, 73%, 57%,0.5);
   cursor: pointer;
 }
 
+.seeMoreTasks{
+  cursor: pointer;
+  width: calc((100% / 3) - 8px);
+  padding: 1rem;
+  color: #fff;
+  background-color: #041187;
+  border: none;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.15rem;
+}
+
+.seeMoreTasks:hover{
+  box-shadow: 0 1px .5rem rgba(89, 89, 89, 0.8);
+}
+
 /* loading spinner  */
 .loadingBg{
   position: absolute;

--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -6,6 +6,8 @@ $white: #e5e5e5;
 $black: #252525;
 $taskTagLevelBorder: #4169e1;
 $taskTagLevelBg: hsla(225, 73%, 57%,0.5);
+$seeMoreTasksBg: #041187;
+$seeMoreTasksShadow: #595959cc;
 
 .screenReaderOnly{ 
   position: absolute; 
@@ -211,10 +213,10 @@ $taskTagLevelBg: hsla(225, 73%, 57%,0.5);
 
 .seeMoreTasks{
   cursor: pointer;
-  width: calc((100% / 3) - 8px);
+  width: calc((100% / 3) - 0.5rem);
   padding: 1rem;
-  color: #fff;
-  background-color: #041187;
+  color: $white;
+  background-color: $seeMoreTasksBg;
   border: none;
   border-radius: 3px;
   font-size: 0.75rem;
@@ -224,7 +226,7 @@ $taskTagLevelBg: hsla(225, 73%, 57%,0.5);
 }
 
 .seeMoreTasks:hover{
-  box-shadow: 0 1px .5rem rgba(89, 89, 89, 0.8);
+  box-shadow: 0 1px .5rem $seeMoreTasksShadow;
 }
 
 /* loading spinner  */

--- a/src/components/tasks/constants.js
+++ b/src/components/tasks/constants.js
@@ -1,0 +1,3 @@
+export const INITIAL_TASKS_LIMIT = 3;
+export const ADD_MORE_TASKS_LIMIT = 5;
+export const SEE_MORE = 'See More';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,11 +24,11 @@ import {
   VERIFIED,
   BLOCKED,
 } from '@/components/constants/task-status';
-import beautifyTaskStatus from '@/helperFunctions/beautifyTaskStatus';
 import updateTasksStatus from '@/helperFunctions/updateTasksStatus';
 import { useAppContext } from '@/context';
 import { isUserAuthorizedContext } from '@/context/isUserAuthorized';
 import { TasksProvider } from '@/context/tasks.context';
+import TaskList from '@/components/tasks/TaskList/TaskList';
 
 const { SUCCESS, ERROR } = ToastTypes;
 const TASKS_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/tasks`;
@@ -72,18 +72,6 @@ async function updateCardContent(id: string, cardDetails: task) {
   }
 }
 
-function renderCardList(tasks: task[], isEditable: boolean) {
-  const beautifiedTasks = beautifyTaskStatus(tasks);
-  return beautifiedTasks.map((item: task) => (
-    <Card
-      content={item}
-      key={item.id}
-      shouldEdit={isEditable}
-      onContentChange={async (id: string, newDetails: any) => isEditable
-        && updateCardContent(id, newDetails)}
-    />
-  ));
-}
 
 const Index: FC = () => {
   const { state: appState } = useAppContext();  
@@ -127,7 +115,7 @@ const Index: FC = () => {
                 {Object.keys(filteredTask).length > 0
                   ? Object.keys(filteredTask).map((key) => (
                     <Accordion open={(statusActiveList.includes(key))} title={key} key={key}>
-                      {renderCardList(filteredTask[key], isEditable)}
+                      <TaskList tasks={filteredTask[key]} isEditable={isEditable} updateCardContent={updateCardContent} hasLimit={key == IN_PROGRESS}/>
                     </Accordion>
                   ))
                   : !error && 'No Tasks Found'}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,6 @@
 import { FC, useState, useEffect, useContext } from 'react';
 import Head from '@/components/head';
 import Layout from '@/components/Layout';
-import Card from '@/components/tasks/card';
 import useFetch from '@/hooks/useFetch';
 import classNames from '@/styles/tasks.module.scss';
 import task from '@/interfaces/task.type';


### PR DESCRIPTION
## See More Button For Tasks 
Closes Phase-1 [367](https://github.com/Real-Dev-Squad/website-status/issues/367)

### Before The Change
- Currently, status-site  has  in-progress task  list accordion, on clicking on it shows list of tasks. 


https://user-images.githubusercontent.com/29247011/215776927-9bafb645-d78f-47d4-8223-2474d1e910f7.mp4



### After The Change
- Intially on clicking according we will be showing 3 only tasks and a see more button, and on  each click on **see more** button, we will add 5 more items to the in-progress task list. Once all tasks are rendered **see more button** will be unmounted.
- Further on closing or again opening accordion will show all tasks without **see more** button. 


https://user-images.githubusercontent.com/29247011/215778545-82330018-b7e4-430a-8e83-24429491ed6d.mp4


### Dev Tested
- Yes  [ x ] 
- No  [  ]



