### PR TITLE
Show cloudinary profile image for users

### DIFF
--- a/src/components/availability-panel/drag-drop-context/DraggableComponent.tsx
+++ b/src/components/availability-panel/drag-drop-context/DraggableComponent.tsx
@@ -5,12 +5,12 @@ import {
 } from 'react-beautiful-dnd';
 import { FC, useContext } from 'react';
 import { draggableProps } from '@/interfaces/availabilityPanel.type';
+import { DUMMY_PROFILE as placeholderImageURL } from '@/components/constants/display-sections';
+import { useGetUsersByUsernameQuery } from '@/app/services/usersApi';
 import classNames from '@/components/availability-panel/drag-drop-context/styles.module.scss';
 import { disableDrag } from '.';
 import Image from 'next/image';
 
-const imageGenerator = (name: string) =>
-    `${process.env.NEXT_PUBLIC_GITHUB_IMAGE_URL}/${name}/img.png`;
 
 const getItemStyle = (
     isDragging: boolean,
@@ -38,6 +38,12 @@ const DraggableComponent: FC<draggableProps> = ({
     title = '',
 }) => {
     const draggableIds = useContext(disableDrag);
+        const { data: userResponse } = useGetUsersByUsernameQuery({
+        searchString: draggableId,
+        size: 1,
+    });
+    const draggableUserImageURL: string =
+        userResponse?.users[0]?.picture?.url || placeholderImageURL;
     return (
         <Draggable
             key={draggableId}
@@ -62,14 +68,10 @@ const DraggableComponent: FC<draggableProps> = ({
                     ) : (
                         <div style={{ display: 'flex', alignItems: 'center' }}>
                             <Image
-                                src={imageGenerator(draggableId)}
+                                src={draggableUserImageURL}
                                 alt={draggableId}
                                 width={52}
                                 height={52}
-                                onError={(e) => {
-                                    (e.target as HTMLImageElement).src =
-                                        'dummyProfile.png';
-                                }}
                             />
                             <span>{draggableId}</span>
                         </div>

--- a/src/components/tasks/card/index.tsx
+++ b/src/components/tasks/card/index.tsx
@@ -14,6 +14,7 @@ import TaskLevelEdit from './TaskTagEdit';
 import { updateTaskDetails } from '@/interfaces/taskItem.type';
 import fetch from '@/helperFunctions/fetch';
 import { TASKS_URL } from '@/components/constants/url';
+import { DUMMY_PROFILE as placeholderImageURL} from '@/components/constants/display-sections';
 import styles from '@/components/issues/Card.module.scss';
 import moment from 'moment';
 import { Loader } from './Loader';
@@ -23,6 +24,7 @@ import {
     useDeleteTaskTagLevelMutation,
     useGetTaskTagsQuery,
 } from '@/app/services/taskTagApi';
+import { useGetUsersByUsernameQuery } from '@/app/services/usersApi';
 
 type Props = {
     content: task;
@@ -44,9 +46,12 @@ const Card: FC<Props> = ({
         TASK_STATUS.AVAILABLE,
     ];
     const cardDetails = content;
-    const [assigneeProfilePic, setAssigneeProfilePic] = useState(
-        `${process.env.NEXT_PUBLIC_GITHUB_IMAGE_URL}/${cardDetails.assignee}/img.png`
-    );
+        const { data: userResponse } = useGetUsersByUsernameQuery({
+        searchString: cardDetails.assignee,
+        size: 1,
+    });
+    const assigneeProfileImageURL: string =
+        userResponse?.users[0]?.picture?.url || placeholderImageURL;
     const { SUCCESS, ERROR } = ToastTypes;
     const isUserAuthorized = useContext(isUserAuthorizedContext);
 
@@ -76,9 +81,6 @@ const Card: FC<Props> = ({
             setShowEditButton(true);
         }
     }, [keyLongPressed]);
-
-    const contributorImageOnError = () =>
-        setAssigneeProfilePic('/dummyProfile.png');
 
     const localStartedOn = new Date(parseInt(cardDetails.startedOn, 10) * 1000);
     const fromNowStartedOn = moment(localStartedOn).fromNow();
@@ -430,9 +432,8 @@ const Card: FC<Props> = ({
                         </span>
                         <span className={classNames.contributorImage}>
                             <Image
-                                src={assigneeProfilePic}
-                                alt={`profile picture of ${cardDetails.assignee}`}
-                                onError={contributorImageOnError}
+                                src={assigneeProfileImageURL}
+                                alt={cardDetails.assignee || 'dummy profile'}
                                 width={30}
                                 height={30}
                             />
@@ -586,9 +587,8 @@ const Card: FC<Props> = ({
                             </span>
                             <span className={classNames.contributorImage}>
                                 <Image
-                                    src={assigneeProfilePic}
-                                    alt="Assignee profile picture"
-                                    onError={contributorImageOnError}
+                                    src={assigneeProfileImageURL}
+                                    alt={cardDetails.assignee || 'dummy profile'}
                                     width={45}
                                     height={45}
                                 />


### PR DESCRIPTION
# Show cloudinary profile image for users

## Closes #470

### What is the change?

- `src/app/services/usersApi.ts` - Added transformResponse to return the response data
- `src/components/availability-panel/drag-drop-context/DraggableComponent.tsx` - Get the response data from the userApi service and use it to display the profile image.
- `src/components/tasks/card/index.tsx` - Get the response data from the userApi service and use it to display the profile image.

### Is Development Tested?

- [x] Yes
- [ ] No

### After Change Screenshots

![image](https://user-images.githubusercontent.com/70854507/229683934-2669eaca-c5fc-4d3a-8787-72820cc5019d.png)

