### PR TITLE
add pre commit hook to fix prettier issues before commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn prettier:fix
+yarn prettier
 yarn run lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+yarn prettier:fix
 yarn run lint-staged

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -6,7 +6,10 @@ import Accordion, { Props } from './index';
 export default {
     title: 'Example/Accordion',
     component: Accordion,
-    argTypes: { title: { control: 'text' }, open: { control: 'boolean' } },
+    argTypes: {
+        title: { control: 'text' },
+        open: { control: 'boolean' },
+    },
 } as Meta;
 
 const Template: Story<Props> = (args) => <Accordion {...args} />;

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -6,10 +6,7 @@ import Accordion, { Props } from './index';
 export default {
     title: 'Example/Accordion',
     component: Accordion,
-    argTypes: {
-        title: { control: 'text' },
-        open: { control: 'boolean' },
-    },
+    argTypes: { title: { control: 'text' }, open: { control: 'boolean' } },
 } as Meta;
 
 const Template: Story<Props> = (args) => <Accordion {...args} />;


### PR DESCRIPTION
This PR is to improve the developer experience for developers working on the status site.

It ensures a prettier check is run before committing the file to the repository.
in case the prettier check fails developers can run `yarn prettier:fix` to fix the prettier issue.
