### PR TITLE
move issues test from a seperate pages folder to common pages folder

### DIFF
--- a/__tests__/Unit/pages/issues/Issues.test.tsx
+++ b/__tests__/Unit/pages/issues/Issues.test.tsx
@@ -4,8 +4,8 @@ import { store } from '@/app/store';
 import { Provider } from 'react-redux';
 import { renderWithRouter } from '@/test_utils/createMockRouter';
 import { setupServer } from 'msw/node';
-import handlers from '../../../__mocks__/handlers';
-import { issuesNoDataFoundHandler } from '../../../__mocks__/handlers/issues.handler';
+import handlers from '../../../../__mocks__/handlers';
+import { issuesNoDataFoundHandler } from '../../../../__mocks__/handlers/issues.handler';
 
 const server = setupServer(...handlers);
 


### PR DESCRIPTION
THere was a new folder named `Pages`(capital P) I moved the issues to a precreated folder named `pages/issues`(small P)