### PR TITLE
Task Card Title Display Enhancement

### DIFF
--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -45,9 +45,12 @@ $seeMoreTasksShadow: #595959cc;
 }
 .cardItems {
     display: flex;
-    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
+
+    @media (max-width: 48rem) {
+        flex-wrap: wrap;
+    }
 }
 .card_updated .cardItems:not(:nth-child(1)) {
     margin-top: 0.8rem;
@@ -59,8 +62,16 @@ $seeMoreTasksShadow: #595959cc;
 
 .cardTitle {
     font-size: 1.6rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     font-weight: 500;
     color: #041187;
+
+    @media (max-width: 48rem) {
+        width: 100%;
+        white-space: normal;
+    }
 }
 
 .cardSpecialFont {


### PR DESCRIPTION

### Closes : #565 

**Description:**
This pull request addresses the issue of task card titles not being displayed correctly when the title is long and wrapping to multiple lines. The proposed changes aim to improve the task card title display by ensuring that long titles are shown in a single line with an ellipsis (...) to indicate that the title has been truncated.

**Changes Made:**

1. Updated the CSS styles for task card titles to enforce a single line display.
2. Added the text-overflow: ellipsis property to truncate long titles with an ellipsis when they exceed the available width.

**After Changes**

https://github.com/Real-Dev-Squad/website-status/assets/70854507/e51cac31-de91-489a-95e9-28db10d09209

