### PR TITLE
Add library for render Markdown in HTML

### DIFF
--- a/__mocks__/db/issues.ts
+++ b/__mocks__/db/issues.ts
@@ -22,11 +22,11 @@ export const issuesResponseSearchedWithoutQuery = [
         state: 'open',
         locked: false,
         assignee: {
-            login: 'whyDontI',
+            login: 'dummyuser',
         },
         assignees: [
             {
-                login: 'whyDontI',
+                login: 'dummyuser',
             },
         ],
         created_at: '2020-10-30T02:08:48Z',
@@ -94,12 +94,14 @@ export const issuesResponseSearchedWithQuery = [
         number: 148,
         title: 'One-Click Issue to Task Conversion v1 Release',
         user: {
-            login: 'bharati-21',
+            login: 'dunnyuser',
+            html_url: 'https://github.com/dummyuser',
         },
         labels: [],
         state: 'open',
         assignee: {
             login: 'dummyuser',
+            html_url: 'https://github.com/dummyuser',
         },
         assignees: [
             {

--- a/__mocks__/db/issues.ts
+++ b/__mocks__/db/issues.ts
@@ -1,22 +1,22 @@
 export const issuesResponseSearchedWithoutQuery = [
     {
-        url: 'https://api.github.com/repos/Real-Dev-Squad/todo-action-items/issues/11',
+        url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/11',
         repository_url:
-            'https://api.github.com/repos/Real-Dev-Squad/todo-action-items',
+            'https://api.github.com/repos/Dummy-Org/todo-action-items',
         labels_url:
-            'https://api.github.com/repos/Real-Dev-Squad/todo-action-items/issues/11/labels{/name}',
+            'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/11/labels{/name}',
         comments_url:
-            'https://api.github.com/repos/Real-Dev-Squad/todo-action-items/issues/11/comments',
+            'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/11/comments',
         events_url:
-            'https://api.github.com/repos/Real-Dev-Squad/todo-action-items/issues/11/events',
+            'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/11/events',
         html_url:
-            'https://github.com/Real-Dev-Squad/todo-action-items/issues/11',
+            'https://github.com/Dummy-Org/todo-action-items/issues/11',
         id: 732825067,
         node_id: 'MDU6SXNzdWU3MzI4MjUwNjc=',
         number: 11,
         title: 'Status view to all features being built for our app',
         user: {
-            login: 'ankushdharkar',
+            login: 'dummyuser',
         },
         labels: [],
         state: 'open',
@@ -36,46 +36,46 @@ export const issuesResponseSearchedWithoutQuery = [
             id: 291388556,
             node_id: 'MDEwOlJlcG9zaXRvcnkyOTEzODg1NTY=',
             name: 'todo-action-items',
-            full_name: 'Real-Dev-Squad/todo-action-items',
+            full_name: 'Dummy-Org/todo-action-items',
             private: false,
             owner: {
-                login: 'Real-Dev-Squad',
+                login: 'Dummy-Org',
                 id: 62176136,
                 node_id: 'MDEyOk9yZ2FuaXphdGlvbjYyMTc2MTM2',
                 avatar_url:
                     'https://avatars.githubusercontent.com/u/62176136?v=4',
                 gravatar_id: '',
-                url: 'https://api.github.com/users/Real-Dev-Squad',
-                html_url: 'https://github.com/Real-Dev-Squad',
+                url: 'https://api.github.com/users/Dummy-Org',
+                html_url: 'https://github.com/Dummy-Org',
                 followers_url:
-                    'https://api.github.com/users/Real-Dev-Squad/followers',
+                    'https://api.github.com/users/Dummy-Org/followers',
                 following_url:
-                    'https://api.github.com/users/Real-Dev-Squad/following{/other_user}',
+                    'https://api.github.com/users/Dummy-Org/following{/other_user}',
                 gists_url:
-                    'https://api.github.com/users/Real-Dev-Squad/gists{/gist_id}',
+                    'https://api.github.com/users/Dummy-Org/gists{/gist_id}',
                 starred_url:
-                    'https://api.github.com/users/Real-Dev-Squad/starred{/owner}{/repo}',
+                    'https://api.github.com/users/Dummy-Org/starred{/owner}{/repo}',
                 subscriptions_url:
-                    'https://api.github.com/users/Real-Dev-Squad/subscriptions',
+                    'https://api.github.com/users/Dummy-Org/subscriptions',
                 organizations_url:
-                    'https://api.github.com/users/Real-Dev-Squad/orgs',
-                repos_url: 'https://api.github.com/users/Real-Dev-Squad/repos',
+                    'https://api.github.com/users/Dummy-Org/orgs',
+                repos_url: 'https://api.github.com/users/Dummy-Org/repos',
                 events_url:
-                    'https://api.github.com/users/Real-Dev-Squad/events{/privacy}',
+                    'https://api.github.com/users/Dummy-Org/events{/privacy}',
                 received_events_url:
-                    'https://api.github.com/users/Real-Dev-Squad/received_events',
+                    'https://api.github.com/users/Dummy-Org/received_events',
                 type: 'Organization',
                 site_admin: false,
             },
-            html_url: 'https://github.com/Real-Dev-Squad/todo-action-items',
+            html_url: 'https://github.com/Dummy-Org/todo-action-items',
             description: 'A running list of todo items for Real Dev Squad site',
-            url: 'https://api.github.com/repos/Real-Dev-Squad/todo-action-items',
+            url: 'https://api.github.com/repos/Dummy-Org/todo-action-items',
             created_at: '2020-08-30T02:52:37Z',
             updated_at: '2023-01-21T05:28:18Z',
             pushed_at: '2020-08-30T02:54:37Z',
             clone_url:
-                'https://github.com/Real-Dev-Squad/todo-action-items.git',
-            svn_url: 'https://github.com/Real-Dev-Squad/todo-action-items',
+                'https://github.com/Dummy-Org/todo-action-items.git',
+            svn_url: 'https://github.com/Dummy-Org/todo-action-items',
         },
         body: 'We want to have a status page where we can view (and in future sort, filter) all the major tasks happening under development.\r\n\r\nThis will give us some visibility into what everyone is currently building and make it easier to collaborate.\r\n\r\nFirst view would look like this:\r\n![Roadmap](https://user-images.githubusercontent.com/1935403/97651644-ebf2e200-1a19-11eb-8a92-026d10ed8eee.png)\r\n',
     },
@@ -83,17 +83,12 @@ export const issuesResponseSearchedWithoutQuery = [
 
 export const issuesResponseSearchedWithQuery = [
     {
-        url: 'https://api.github.com/repos/Real-Dev-Squad/todo-action-items/issues/148',
-        repository_url:
-            'https://api.github.com/repos/Real-Dev-Squad/todo-action-items',
-        labels_url:
-            'https://api.github.com/repos/Real-Dev-Squad/todo-action-items/issues/148/labels{/name}',
-        comments_url:
-            'https://api.github.com/repos/Real-Dev-Squad/todo-action-items/issues/148/comments',
-        events_url:
-            'https://api.github.com/repos/Real-Dev-Squad/todo-action-items/issues/148/events',
-        html_url:
-            'https://github.com/Real-Dev-Squad/todo-action-items/issues/148',
+        url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/148',
+        repository_url: 'https://api.github.com/repos/Dummy-Org/todo-action-items',
+        labels_url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/148/labels{/name}',
+        comments_url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/148/comments',
+        events_url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/148/events',
+        html_url: 'https://github.com/Dummy-Org/todo-action-items/issues/148',
         id: 1686179699,
         node_id: 'I_kwDOEV48jM5kgQ9z',
         number: 148,
@@ -104,18 +99,52 @@ export const issuesResponseSearchedWithQuery = [
         labels: [],
         state: 'open',
         assignee: {
-            login: 'ankushdharkar',
+            login: 'dummyuser',
         },
         assignees: [
             {
-                login: 'ankushdharkar',
+                login: 'dummyuser',
             },
         ],
         comments: 0,
         created_at: '2023-04-27T06:10:50Z',
         updated_at: '2023-04-27T23:21:52Z',
         closed_at: null,
-        body: '# One-Click Issue To Task Conversion- v1 Release\r\n### Closes #92 \r\n\r\nThe following sub-tasks are to be completed to release one-click issue to task conversion feature to main branch\r\n- [x] https://github.com/Real-Dev-Squad/website-status/pull/474\r\n- [ ] #137 \r\n- [ ] #136 \r\n- [ ] [Merge website-backend changes from develop to main](https://github.com/Real-Dev-Squad/website-backend/pull/1047)\r\n- [x] [Merge website-status changes to develop](https://github.com/Real-Dev-Squad/website-status/pull/474)\r\n- [ ] Merge website-status changes from develop to main\r\n- [ ] Alert\r\n- [ ] Verify changes',
+        body:
+            '# One-Click Issue To Task Conversion- v1 Release\r\n### Closes #92 \r\n\r\nThe following sub-tasks are to be completed to release one-click issue to task conversion feature to main branch\r\n- [x] https://github.com/Dummy-Org/website-status/pull/474\r\n- [ ] #137 \r\n- [ ] #136 \r\n- [ ] [Merge website-backend changes from develop to main](https://github.com/Dummy-Org/website-backend/pull/1047)\r\n- [x] [Merge website-status changes to develop](https://github.com/Dummy-Org/website-status/pull/474)\r\n- [ ] Merge website-status changes from develop to main\r\n- [ ] Alert\r\n- [ ] Verify changes',
         taskExists: true,
     },
 ];
+
+export const issueResponseNullBody =
+{
+    url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/149',
+    repository_url: 'https://api.github.com/repos/Dummy-Org/todo-action-items',
+    labels_url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/149/labels{/name}',
+    comments_url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/149/comments',
+    events_url: 'https://api.github.com/repos/Dummy-Org/todo-action-items/issues/149/events',
+    html_url: 'https://github.com/Dummy-Org/todo-action-items/issues/149',
+    id: 1686179700,
+    node_id: 'I_kwDOEV48jM5kgQ9z',
+    number: 149,
+    title: 'Dummy Issue with Null Body',
+    user: {
+        login: 'dummyuser',
+    },
+    labels: [],
+    state: 'open',
+    assignee: {
+        login: 'dummyassignee',
+    },
+    assignees: [
+        {
+            login: 'dummyassignee',
+        },
+    ],
+    comments: 0,
+    created_at: '2023-04-27T06:10:50Z',
+    updated_at: '2023-04-27T23:21:52Z',
+    closed_at: null,
+    body: null,
+    taskExists: false,
+};

--- a/__tests__/Unit/Components/Issues/Card.test.tsx
+++ b/__tests__/Unit/Components/Issues/Card.test.tsx
@@ -1,85 +1,87 @@
 import { render } from '@testing-library/react';
 import Card from '@/components/issues/Card';
 import MarkdownRenderer from '@/components/MarkdownRenderer/MarkdownRenderer';
-import { IssueItem } from '@/interfaces/issueItem.type';
+import Markdown from 'markdown-to-jsx';
 
-const issue_one: IssueItem = {
-    html_url: 'https://github.com/dummy-owner/dummy-repo/issues/11',
-    id: 732825067,
-    title: 'Dummy issue',
-    user: {
-        login: 'dummyuser',
-        html_url: 'https://github.com/dummyuser',
-    },
-    labels: [],
-    state: 'open',
-    assignee: {
-        login: 'dummyassignee',
-        html_url: 'https://github.com/dummyassignee',
-    },
-    created_at: '2020-10-30T02:08:48Z',
-    body: null,
-};
-const issue_two: IssueItem = {
-    html_url: 'https://github.com/dummy-owner/dummy-repo/issues/11',
-    id: 732825067,
-    title: 'Dummy issue',
-    user: {
-        login: 'dummyuser',
-        html_url: 'https://github.com/dummyuser',
-    },
-    labels: [],
-    state: 'open',
-    assignee: {
-        login: 'dummyassignee',
-        html_url: 'https://github.com/dummyassignee',
-    },
-    created_at: '2020-10-30T02:08:48Z',
-    body: 'Dummy issue description',
-};
+import {
+    issueResponseNullBody,
+    issuesResponseSearchedWithQuery,
+} from '../../../../__mocks__/db/issues';
 
 describe('Issue card', () => {
     test('Should render issue information correctly', () => {
-        const screen = render(<Card issue={issue_one} />);
+        const screen = render(
+            <Card issue={issuesResponseSearchedWithQuery[0]} />
+        );
 
-        expect(screen.getByText(issue_one.title)).toBeInTheDocument();
-        expect(screen.getByText(issue_one.html_url)).toBeInTheDocument();
+        expect(
+            screen.getByText(issuesResponseSearchedWithQuery[0].title)
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(issuesResponseSearchedWithQuery[0].html_url)
+        ).toBeInTheDocument();
         expect(screen.getByRole('button')).toHaveTextContent('Convert to task');
     });
 
     test('Should render issue created by information correctly', () => {
-        const screen = render(<Card issue={issue_one} />);
-        const date = new Date(issue_one.created_at).toDateString();
-        const issueUser = screen.getByText(issue_one.user.login);
+        const screen = render(
+            <Card issue={issuesResponseSearchedWithQuery[0]} />
+        );
+        const date = new Date(
+            issuesResponseSearchedWithQuery[0].created_at
+        ).toDateString();
+        const issueUser = screen.getByText(
+            issuesResponseSearchedWithQuery[0].user.login
+        );
         expect(screen.getByText(`Opened on ${date} by`)).toBeInTheDocument();
         expect(issueUser).toBeInTheDocument();
-        expect(issueUser).toHaveAttribute('href', issue_one.user.html_url);
+        expect(issueUser).toHaveAttribute(
+            'href',
+            issuesResponseSearchedWithQuery[0].user.html_url
+        );
     });
 
     test('Should render the assignee information correctly', () => {
-        const screen = render(<Card issue={issue_one} />);
-        const assignee = screen.getByText(issue_one.assignee?.login);
+        const screen = render(
+            <Card issue={issuesResponseSearchedWithQuery[0]} />
+        );
+        const assignee = screen.getByText(
+            issuesResponseSearchedWithQuery[0].assignee?.login
+        );
         expect(assignee).toBeInTheDocument();
-        expect(assignee).toHaveAttribute('href', issue_one.assignee?.html_url);
+        expect(assignee).toHaveAttribute(
+            'href',
+            issuesResponseSearchedWithQuery[0].assignee?.html_url
+        );
     });
 
-    test('Should render the MarkdownRenderer component with the correct content', () => {
+    test('Should render "No description provided." if the issue body is null', () => {
         const screen = render(
             <MarkdownRenderer
-                content={issue_one.body ?? 'No description provided.'}
+                content={
+                    issueResponseNullBody.body ?? 'No description provided.'
+                }
             />
         );
         const contentElement = screen.getByText(
-            issue_one.body ?? 'No description provided.'
+            issueResponseNullBody.body ?? 'No description provided.'
         );
         expect(contentElement).toBeInTheDocument();
     });
 
     test('Should render the MarkdownRenderer component with the correct content', () => {
-        const screen = render(<Card issue={issue_two} />);
-        const contentElement = screen.getByText(
-            issue_two.body ?? 'No description provided.'
+        const body = issuesResponseSearchedWithQuery[0].body;
+        const screen = render(<MarkdownRenderer content={body} />);
+        const bodyElement = screen.getByText(
+            'One-Click Issue To Task Conversion- v1 Release'
         );
-        expect(contentElement).toBeInTheDocument();
+        const markdownElement = screen.getByText('Closes #92');
+        const markdownElement2 = screen.getByText(
+            'The following sub-tasks are to be completed to release one-click issue to task conversion feature to main branch'
+        );
+
+        expect(bodyElement).toBeInTheDocument();
+        expect(markdownElement).toBeInTheDocument();
+        expect(markdownElement2).toBeInTheDocument();
     });
 });

--- a/__tests__/Unit/Components/Issues/Card.test.tsx
+++ b/__tests__/Unit/Components/Issues/Card.test.tsx
@@ -8,11 +8,13 @@ const DEFAULT_PROPS: IssueItem = {
     title: 'Status view to all features being built for our app',
     user: {
         login: 'ankushdharkar',
+        html_url: 'https://github.com/ankushdharkar',
     },
     labels: [],
     state: 'open',
     assignee: {
         login: 'whyDontI',
+        html_url: 'https://github.com/whyDontI',
     },
     created_at: '2020-10-30T02:08:48Z',
     body: 'We want to have a status page where we can view (and in future sort, filter) all the major tasks happening under development.\r\n\r\nThis will give us some visibility into what everyone is currently building and make it easier to collaborate.\r\n\r\nFirst view would look like this:\r\n![Roadmap](https://user-images.githubusercontent.com/1935403/97651644-ebf2e200-1a19-11eb-8a92-026d10ed8eee.png)\r\n',
@@ -21,13 +23,31 @@ const DEFAULT_PROPS: IssueItem = {
 describe('Issue card', () => {
     test('Should render issue information correctly', () => {
         const screen = render(<Card issue={DEFAULT_PROPS} />);
-        const date = new Date(DEFAULT_PROPS.created_at).toDateString();
 
         expect(screen.getByText(DEFAULT_PROPS.title)).toBeInTheDocument();
         expect(screen.getByText(DEFAULT_PROPS.html_url)).toBeInTheDocument();
-        expect(
-            screen.getByText(`Opened on ${date} by ${DEFAULT_PROPS.user.login}`)
-        ).toBeInTheDocument();
         expect(screen.getByRole('button')).toHaveTextContent('Convert to task');
+    });
+
+    test('Should render issue created by information correctly', () => {
+        const screen = render(<Card issue={DEFAULT_PROPS} />);
+        const date = new Date(DEFAULT_PROPS.created_at).toDateString();
+        const issueUser = screen.getByText(DEFAULT_PROPS.user.login);
+
+        expect(screen.getByText(`Opened on ${date} by`)).toBeInTheDocument();
+        expect(issueUser).toBeInTheDocument();
+        expect(issueUser).toHaveAttribute('href', DEFAULT_PROPS.user.html_url);
+    });
+
+    test('Should render the assignee information correctly', () => {
+        const screen = render(<Card issue={DEFAULT_PROPS} />);
+
+        const assignee = screen.getByText(DEFAULT_PROPS.assignee?.login);
+
+        expect(assignee).toBeInTheDocument();
+        expect(assignee).toHaveAttribute(
+            'href',
+            DEFAULT_PROPS.assignee?.html_url
+        );
     });
 });

--- a/__tests__/Unit/Components/Issues/Card.test.tsx
+++ b/__tests__/Unit/Components/Issues/Card.test.tsx
@@ -9,7 +9,7 @@ const issue_one: IssueItem = {
     title: 'Dummy issue',
     user: {
         login: 'dummyuser',
-        html_url: 'https://github.com/ankushdharkar',
+        html_url: 'https://github.com/dummyuser',
     },
     labels: [],
     state: 'open',
@@ -26,7 +26,7 @@ const issue_two: IssueItem = {
     title: 'Dummy issue',
     user: {
         login: 'dummyuser',
-        html_url: 'https://github.com/ankushdharkar',
+        html_url: 'https://github.com/dummyuser',
     },
     labels: [],
     state: 'open',

--- a/__tests__/Unit/Components/Issues/Card.test.tsx
+++ b/__tests__/Unit/Components/Issues/Card.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import Card from '@/components/issues/Card';
+import MarkdownRenderer from '@/components/MarkdownRenderer/MarkdownRenderer';
 import { IssueItem } from '@/interfaces/issueItem.type';
 
 const DEFAULT_PROPS: IssueItem = {
@@ -17,7 +18,6 @@ const DEFAULT_PROPS: IssueItem = {
         html_url: 'https://github.com/whyDontI',
     },
     created_at: '2020-10-30T02:08:48Z',
-    body: 'We want to have a status page where we can view (and in future sort, filter) all the major tasks happening under development.\r\n\r\nThis will give us some visibility into what everyone is currently building and make it easier to collaborate.\r\n\r\nFirst view would look like this:\r\n![Roadmap](https://user-images.githubusercontent.com/1935403/97651644-ebf2e200-1a19-11eb-8a92-026d10ed8eee.png)\r\n',
 };
 
 describe('Issue card', () => {
@@ -49,5 +49,19 @@ describe('Issue card', () => {
             'href',
             DEFAULT_PROPS.assignee?.html_url
         );
+    });
+
+    test('Should render the MarkdownRenderer component with the correct content', () => {
+        const screen = render(
+            <MarkdownRenderer
+                content={DEFAULT_PROPS.body ?? 'No description provided.'}
+            />
+        );
+
+        const contentElement = screen.getByText(
+            DEFAULT_PROPS.body ?? 'No description provided.'
+        );
+
+        expect(contentElement).toBeInTheDocument();
     });
 });

--- a/__tests__/Unit/Components/Issues/Card.test.tsx
+++ b/__tests__/Unit/Components/Issues/Card.test.tsx
@@ -3,65 +3,83 @@ import Card from '@/components/issues/Card';
 import MarkdownRenderer from '@/components/MarkdownRenderer/MarkdownRenderer';
 import { IssueItem } from '@/interfaces/issueItem.type';
 
-const DEFAULT_PROPS: IssueItem = {
-    html_url: 'https://github.com/Real-Dev-Squad/todo-action-items/issues/11',
+const issue_one: IssueItem = {
+    html_url: 'https://github.com/dummy-owner/dummy-repo/issues/11',
     id: 732825067,
-    title: 'Status view to all features being built for our app',
+    title: 'Dummy issue',
     user: {
-        login: 'ankushdharkar',
+        login: 'dummyuser',
         html_url: 'https://github.com/ankushdharkar',
     },
     labels: [],
     state: 'open',
     assignee: {
-        login: 'whyDontI',
-        html_url: 'https://github.com/whyDontI',
+        login: 'dummyassignee',
+        html_url: 'https://github.com/dummyassignee',
     },
     created_at: '2020-10-30T02:08:48Z',
+    body: null,
+};
+const issue_two: IssueItem = {
+    html_url: 'https://github.com/dummy-owner/dummy-repo/issues/11',
+    id: 732825067,
+    title: 'Dummy issue',
+    user: {
+        login: 'dummyuser',
+        html_url: 'https://github.com/ankushdharkar',
+    },
+    labels: [],
+    state: 'open',
+    assignee: {
+        login: 'dummyassignee',
+        html_url: 'https://github.com/dummyassignee',
+    },
+    created_at: '2020-10-30T02:08:48Z',
+    body: 'Dummy issue description',
 };
 
 describe('Issue card', () => {
     test('Should render issue information correctly', () => {
-        const screen = render(<Card issue={DEFAULT_PROPS} />);
+        const screen = render(<Card issue={issue_one} />);
 
-        expect(screen.getByText(DEFAULT_PROPS.title)).toBeInTheDocument();
-        expect(screen.getByText(DEFAULT_PROPS.html_url)).toBeInTheDocument();
+        expect(screen.getByText(issue_one.title)).toBeInTheDocument();
+        expect(screen.getByText(issue_one.html_url)).toBeInTheDocument();
         expect(screen.getByRole('button')).toHaveTextContent('Convert to task');
     });
 
     test('Should render issue created by information correctly', () => {
-        const screen = render(<Card issue={DEFAULT_PROPS} />);
-        const date = new Date(DEFAULT_PROPS.created_at).toDateString();
-        const issueUser = screen.getByText(DEFAULT_PROPS.user.login);
-
+        const screen = render(<Card issue={issue_one} />);
+        const date = new Date(issue_one.created_at).toDateString();
+        const issueUser = screen.getByText(issue_one.user.login);
         expect(screen.getByText(`Opened on ${date} by`)).toBeInTheDocument();
         expect(issueUser).toBeInTheDocument();
-        expect(issueUser).toHaveAttribute('href', DEFAULT_PROPS.user.html_url);
+        expect(issueUser).toHaveAttribute('href', issue_one.user.html_url);
     });
 
     test('Should render the assignee information correctly', () => {
-        const screen = render(<Card issue={DEFAULT_PROPS} />);
-
-        const assignee = screen.getByText(DEFAULT_PROPS.assignee?.login);
-
+        const screen = render(<Card issue={issue_one} />);
+        const assignee = screen.getByText(issue_one.assignee?.login);
         expect(assignee).toBeInTheDocument();
-        expect(assignee).toHaveAttribute(
-            'href',
-            DEFAULT_PROPS.assignee?.html_url
-        );
+        expect(assignee).toHaveAttribute('href', issue_one.assignee?.html_url);
     });
 
     test('Should render the MarkdownRenderer component with the correct content', () => {
         const screen = render(
             <MarkdownRenderer
-                content={DEFAULT_PROPS.body ?? 'No description provided.'}
+                content={issue_one.body ?? 'No description provided.'}
             />
         );
-
         const contentElement = screen.getByText(
-            DEFAULT_PROPS.body ?? 'No description provided.'
+            issue_one.body ?? 'No description provided.'
         );
+        expect(contentElement).toBeInTheDocument();
+    });
 
+    test('Should render the MarkdownRenderer component with the correct content', () => {
+        const screen = render(<Card issue={issue_two} />);
+        const contentElement = screen.getByText(
+            issue_two.body ?? 'No description provided.'
+        );
         expect(contentElement).toBeInTheDocument();
     });
 });

--- a/__tests__/Unit/Components/Issues/Card.test.tsx
+++ b/__tests__/Unit/Components/Issues/Card.test.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import Card from '@/components/issues/Card';
 import MarkdownRenderer from '@/components/MarkdownRenderer/MarkdownRenderer';
-import Markdown from 'markdown-to-jsx';
 
 import {
     issueResponseNullBody,
@@ -9,14 +8,21 @@ import {
 } from '../../../../__mocks__/db/issues';
 
 describe('Issue card', () => {
+    test('Should render issue title correctly', () => {
+        const screen = render(
+            <MarkdownRenderer
+                content={issuesResponseSearchedWithQuery[0].title}
+            />
+        );
+        const titleElement = screen.getByText(
+            'One-Click Issue to Task Conversion v1 Release'
+        );
+        expect(titleElement).toBeInTheDocument();
+    });
     test('Should render issue information correctly', () => {
         const screen = render(
             <Card issue={issuesResponseSearchedWithQuery[0]} />
         );
-
-        expect(
-            screen.getByText(issuesResponseSearchedWithQuery[0].title)
-        ).toBeInTheDocument();
         expect(
             screen.getByText(issuesResponseSearchedWithQuery[0].html_url)
         ).toBeInTheDocument();

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "ISC",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.1",
+    "markdown-to-jsx": "^7.2.0",
     "axios": "^1.2.2",
     "moment": "^2.29.4",
     "next": "^13.1.1",

--- a/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Markdown from 'markdown-to-jsx';
+
+interface MarkdownRendererProps {
+    content: string;
+    className?: string;
+}
+
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
+    content,
+    className,
+}) => {
+    return <Markdown className={className}>{content}</Markdown>;
+};
+
+export default MarkdownRenderer;

--- a/src/components/issues/Card.module.scss
+++ b/src/components/issues/Card.module.scss
@@ -27,6 +27,10 @@ $card-text: #78716c;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 0.5rem;
+    h2 {
+        font-size: 1.5rem;
+        margin: 0;
+    }
 
     @media (max-width: 48rem) {
         flex-direction: column;
@@ -40,8 +44,19 @@ $card-text: #78716c;
     margin-left: 0.5rem;
 }
 
-.card__issue_created__by {
-    margin: 0.2rem 0;
+.card__issue_created__by,
+.card__assignee {
+    margin-bottom: 0.5rem;
+
+    a {
+        color: styles.$link-text;
+        text-decoration: none;
+        margin-left: 0.2rem;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
 }
 
 .card__body__description {
@@ -54,14 +69,17 @@ $card-text: #78716c;
 .card__link {
     font-family: 'Inter';
     font-style: normal;
-    font-weight: 500;
-    font-size: 1rem;
+    font-size: 0.8rem;
     line-height: 140%;
-    /* or 17px */
     color: $card-text;
 
     & a {
         color: styles.$link-text;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
     }
 }
 
@@ -73,7 +91,8 @@ $card-text: #78716c;
     border-radius: 1.25rem;
     background: styles.$link-bg;
     font-weight: 500;
-    text-transform: uppercase;
+    font-family: 'Inter';
+    margin-right: 0.5rem;
 }
 
 .label__block {
@@ -103,6 +122,11 @@ $card-text: #78716c;
         td {
             border: 1px solid $card-text;
             padding: 0.5rem;
+        }
+
+        @media (max-width: 48rem) {
+            display: block;
+            overflow-x: auto;
         }
     }
 

--- a/src/components/issues/Card.module.scss
+++ b/src/components/issues/Card.module.scss
@@ -11,7 +11,7 @@ $card-text: #78716c;
     transition: 0.2s ease-out;
     display: flex;
     flex-direction: column;
-    margin: 2rem auto;
+    margin: 1rem auto;
     justify-content: space-between;
     position: relative;
 
@@ -22,50 +22,40 @@ $card-text: #78716c;
     }
 }
 
-.card__top {
+.card__top__details__button {
     display: flex;
-    align-items: flex-start;
-    gap: 2rem;
-}
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
 
-.card__top__details {
-    flex: 1;
-    max-width: 75%;
-    overflow-x: clip;
-}
-
-.card__top__details__meta_data {
-    margin: 0 0 0.75rem;
-
-    & h2 {
-        font-weight: 600;
-        font-size: 1.5rem;
-        margin: 0 0 0.25rem;
-        color: #1c1917;
+    @media (max-width: 48rem) {
+        flex-direction: column;
+        align-items: center;
     }
-
-    & p {
-        font-size: 0.875rem;
-        font-weight: 500;
-        color: $card-text;
-    }
-}
-
-.card__top__details__desc {
-    color: $card-text;
 }
 
 .card__top__button {
     @include styles.issues-button;
+    min-width: 9rem;
+    margin-left: 0.5rem;
+}
+
+.card__issue_created__by {
+    margin: 0.2rem 0;
+}
+
+.card__body__description {
+    img {
+        max-width: 100%;
+        height: auto;
+    }
 }
 
 .card__link {
-    width: 440px;
-
     font-family: 'Inter';
     font-style: normal;
     font-weight: 500;
-    font-size: 12px;
+    font-size: 1rem;
     line-height: 140%;
     /* or 17px */
     color: $card-text;
@@ -78,14 +68,46 @@ $card-text: #78716c;
 .label {
     display: block;
     padding: 0.5rem 0.75rem;
-    font-size: 0.875rem;
+    font-size: 0.8rem;
     border: none;
     border-radius: 1.25rem;
     background: styles.$link-bg;
-    color: styles.$link-text;
     font-weight: 500;
+    text-transform: uppercase;
 }
 
 .label__block {
     display: flex;
+}
+
+.card__body {
+    width: 100%;
+    color: black;
+
+    h1 {
+        font-size: 1.2rem;
+    }
+    img {
+        max-width: 100%;
+        margin: 0.5rem 0;
+        border: 1px solid $card-text;
+        border-radius: 0.5rem;
+    }
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        border: 1px solid $card-text;
+        border-radius: 0.5rem;
+        margin: 0.5rem 0;
+        th,
+        td {
+            border: 1px solid $card-text;
+            padding: 0.5rem;
+        }
+    }
+
+    code {
+        font-family: consolas, monospace;
+        font-size: 0.875rem;
+    }
 }

--- a/src/components/issues/Card.tsx
+++ b/src/components/issues/Card.tsx
@@ -76,7 +76,11 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
             </div>
             <p className={styles.card__issue_created__by}>
                 Opened on {created} by
-                <a href={issue.user.html_url} target="_blank" rel="noreferrer">
+                <a
+                    href={issue.user.html_url ?? '#'}
+                    target="_blank"
+                    rel="noreferrer"
+                >
                     {issue.user.login}
                 </a>
             </p>
@@ -90,7 +94,7 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
                 <p className={styles.card__assignee}>
                     Assigned to:
                     <a
-                        href={issue.assignee?.html_url}
+                        href={issue.assignee?.html_url ?? '#'}
                         target="_blank"
                         rel="noreferrer"
                     >

--- a/src/components/issues/Card.tsx
+++ b/src/components/issues/Card.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react';
 import styles from '@/components/issues/Card.module.scss';
+import MarkdownRenderer from '@/components/MarkdownRenderer/MarkdownRenderer';
 import { toast, ToastTypes } from '@/helperFunctions/toast';
 
 import fetch from '@/helperFunctions/fetch';
@@ -61,44 +62,11 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
 
     return (
         <div className={styles.card}>
-            <div className={styles.card__top}>
-                <div className={styles.card__top__details}>
-                    <div className={styles.card__top__details__meta_data}>
-                        <h2 className={styles.card__title}>{issue.title}</h2>
-                        <p>
-                            Opened on {created} by {issue.user.login}
-                            <br></br>
-                        </p>
-                        <p className="card__body">{issue.body}</p>
-                        {issue.assignee
-                            ? 'Assigned to ' + issue.assignee.login
-                            : ''}
-                        <p className={styles.card__link}>
-                            Issue Link :{' '}
-                            <a
-                                href={issue.html_url}
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                {issue.html_url}
-                            </a>{' '}
-                        </p>
-                    </div>
-
-                    <div className={styles.label__block}>
-                        {issue.labels.map(
-                            (label: {
-                                id: number | null | undefined;
-                                name: string | null | undefined;
-                            }) => (
-                                <button className={styles.label} key={label.id}>
-                                    {label.name}
-                                </button>
-                            )
-                        )}
-                    </div>
-                </div>
-
+            <div className={styles.card__top__details__button}>
+                {/* <h2 className={styles.card__title}>{issue.title}</h2> */}
+                <h2 className={styles.card__title}>
+                    <MarkdownRenderer content={issue.title} />
+                </h2>
                 <button
                     className={styles.card__top__button}
                     disabled={taskExists || isLoading}
@@ -106,6 +74,35 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
                 >
                     Convert to task
                 </button>
+            </div>
+            <p className={styles.card__issue_created__by}>
+                Opened on {created} by {issue.user.login}
+            </p>
+            <div className="card__body">
+                <MarkdownRenderer
+                    className={styles.card__body}
+                    content={issue.body ?? ''}
+                />
+            </div>
+            {issue.assignee && 'Assigned to ' + issue.assignee.login}
+            <p className={styles.card__link}>
+                Issue Link :{' '}
+                <a href={issue.html_url} target="_blank" rel="noreferrer">
+                    {issue.html_url}
+                </a>{' '}
+            </p>
+
+            <div className={styles.label__block}>
+                {issue.labels.map(
+                    (label: {
+                        id: number | null | undefined;
+                        name: string | null | undefined;
+                    }) => (
+                        <button className={styles.label} key={label.id}>
+                            {label.name}
+                        </button>
+                    )
+                )}
             </div>
         </div>
     );

--- a/src/components/issues/Card.tsx
+++ b/src/components/issues/Card.tsx
@@ -9,7 +9,7 @@ import { TASKS_URL } from '../../constants/url';
 const { SUCCESS, ERROR } = ToastTypes;
 
 const Card: FC<IssueCardProps> = ({ issue }) => {
-    const created = new Date(issue.created_at).toDateString();
+    const date = new Date(issue.created_at).toDateString();
     const [taskExists, setTaskExists] = useState(issue.taskExists ?? false);
     const [isLoading, setIsLoading] = useState(false);
 
@@ -75,7 +75,7 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
                 </button>
             </div>
             <p className={styles.card__issue_created__by}>
-                Opened on {created} by
+                Opened on {date} by
                 <a
                     href={issue.user.html_url ?? '#'}
                     target="_blank"

--- a/src/components/issues/Card.tsx
+++ b/src/components/issues/Card.tsx
@@ -63,7 +63,6 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
     return (
         <div className={styles.card}>
             <div className={styles.card__top__details__button}>
-                {/* <h2 className={styles.card__title}>{issue.title}</h2> */}
                 <h2 className={styles.card__title}>
                     <MarkdownRenderer content={issue.title} />
                 </h2>
@@ -76,15 +75,29 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
                 </button>
             </div>
             <p className={styles.card__issue_created__by}>
-                Opened on {created} by {issue.user.login}
+                Opened on {created} by
+                <a href={issue.user.html_url} target="_blank" rel="noreferrer">
+                    {issue.user.login}
+                </a>
             </p>
             <div className="card__body">
                 <MarkdownRenderer
                     className={styles.card__body}
-                    content={issue.body ?? ''}
+                    content={issue.body ?? 'No description provided.'}
                 />
             </div>
-            {issue.assignee && 'Assigned to ' + issue.assignee.login}
+            {issue.assignee && (
+                <p className={styles.card__assignee}>
+                    Assigned to:
+                    <a
+                        href={issue.assignee?.html_url}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        {issue.assignee?.login}
+                    </a>
+                </p>
+            )}
             <p className={styles.card__link}>
                 Issue Link :{' '}
                 <a href={issue.html_url} target="_blank" rel="noreferrer">

--- a/src/interfaces/issueItem.type.ts
+++ b/src/interfaces/issueItem.type.ts
@@ -3,10 +3,12 @@ export type IssueItem = {
     title: string;
     user: {
         login: string | null | undefined;
+        html_url: string | null | undefined;
     };
     assignee:
         | {
               login?: string | null | undefined;
+              html_url?: string | null | undefined;
           }
         | null
         | undefined;

--- a/src/styles/issues.module.scss
+++ b/src/styles/issues.module.scss
@@ -6,10 +6,10 @@ $color-white: #ffffff;
 $color-disabled: #e5e7eb;
 
 @mixin issues-button {
-    background-color: $link-bg;
-    color: $link-text;
+    background-color: $color-blue;
+    color: $color-white;
     display: block;
-    padding: 0.5rem 0.75rem;
+    padding: 0.6rem 0.8rem;
     font-size: 0.875rem;
     border: none;
     border-radius: 0.25rem;
@@ -20,6 +20,10 @@ $color-disabled: #e5e7eb;
         background-color: #f5f5f4;
         color: #57534e;
         cursor: default;
+    }
+
+    &:not(:disabled):hover {
+        background-color: darken($color-blue, 10%);
     }
 }
 
@@ -52,12 +56,4 @@ $color-disabled: #e5e7eb;
 
 .issuesSearchSubmitButton {
     @include issues-button;
-    background-color: $color-blue;
-    color: $color-white;
-    border-radius: 0.25rem;
-    border: none;
-
-    &:not(:disabled):hover {
-        background-color: darken($color-blue, 10%);
-    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9766,11 +9766,6 @@ lz-string@^1.4.4, lz-string@^1.5.0:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
-lz-string@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
-  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
-
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -9831,6 +9826,11 @@ markdown-escapes@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
+
+markdown-to-jsx@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.2.0.tgz#e7b46b65955f6a04d48a753acd55874a14bdda4b"
+  integrity sha512-3l4/Bigjm4bEqjCR6Xr+d4DtM1X6vvtGsMGSjJYyep8RjjIvcWtrXBS8Wbfe1/P+atKNMccpsraESIaWVplzVg==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
### Closes - #572 

**Description:**

I have added a *markdown-to-jsx* package to convert the markdown content to JSX. This package converts the markdown content to JSX and then renders it on the page. For this, I have created a new component called *MarkdownRenderer* which takes the markdown content as a prop and converts it to JSX using the *markdown-to-jsx* package. And I also added the user and assignee `html_url` to the issue card so that the user can directly go to the user's or assignee's profiles by clicking on the link.


**Screenshot**
**Before:**
![Screenshot (175)](https://github.com/Real-Dev-Squad/website-status/assets/70854507/3fbd2868-4360-4e61-8b5f-e65d811b55e4)

**After:**

https://github.com/Real-Dev-Squad/website-status/assets/70854507/04f10b15-9175-47cd-bd7f-be8da0f97b71

