### PR TITLE
add getLatestProgress RTK query to make missed updates dynamic

### DIFF
--- a/src/app/services/progressesApi.ts
+++ b/src/app/services/progressesApi.ts
@@ -17,7 +17,8 @@ export const progressesApi = api.injectEndpoints({
         getLatestProgress: builder.query({
             query: (payload) => `/progresses/?${payload}`,
             transformResponse: (response: taskProgressResponse) => {
-                return response.data[0];
+                if (response.data.length > 0) return response.data[0];
+                else return { id: '', date: Date.now() };
             },
         }),
     }),

--- a/src/app/services/progressesApi.ts
+++ b/src/app/services/progressesApi.ts
@@ -17,7 +17,7 @@ export const progressesApi = api.injectEndpoints({
         getLatestProgress: builder.query({
             query: (payload) => `/progresses/?${payload}`,
             transformResponse: (response: taskProgressResponse) => {
-                return response.data[0].date;
+                return response.data[0];
             },
         }),
     }),

--- a/src/app/services/progressesApi.ts
+++ b/src/app/services/progressesApi.ts
@@ -1,3 +1,4 @@
+import { taskProgressResponse } from '@/types/ProgressUpdates';
 import { api } from './api';
 
 export const progressesApi = api.injectEndpoints({
@@ -13,7 +14,14 @@ export const progressesApi = api.injectEndpoints({
                 },
             }),
         }),
+        getLatestProgress: builder.query({
+            query: (payload) => `/progresses/?${payload}`,
+            transformResponse: (response: taskProgressResponse) => {
+                return response.data[0].date;
+            },
+        }),
     }),
 });
 
-export const { useSaveProgressMutation } = progressesApi;
+export const { useSaveProgressMutation, useGetLatestProgressQuery } =
+    progressesApi;

--- a/src/components/ProgressForm/ProgressHeader.tsx
+++ b/src/components/ProgressForm/ProgressHeader.tsx
@@ -5,18 +5,18 @@ import { useRouter } from 'next/router';
 function ProgressHeader() {
     const router = useRouter();
     const id = router.query.id;
-    const { data } = useGetLatestProgressQuery(`taskId=${id}`);
-    const currentDate = new Date();
-    const lastUpdateDate = new Date(data?.date as number);
+    const { data, error } = useGetLatestProgressQuery(`taskId=${id}`);
+    let missedUpdates = 0;
+    if (!error) {
+        const currentDate = new Date();
+        const lastUpdateDate = new Date(data?.date as number);
+        missedUpdates = currentDate.getDate() - 1 - lastUpdateDate.getDate();
+    }
     return (
         <header className={styles.header}>
             <p>
                 You have{' '}
-                <span className={styles.mark}>
-                    {' '}
-                    {currentDate.getDate() - 1 - lastUpdateDate.getDate()}{' '}
-                    missed
-                </span>{' '}
+                <span className={styles.mark}> {missedUpdates} missed</span>{' '}
                 Progress Updates
             </p>
             <p>Lets try to avoid missing updates</p>

--- a/src/components/ProgressForm/ProgressHeader.tsx
+++ b/src/components/ProgressForm/ProgressHeader.tsx
@@ -1,11 +1,23 @@
+import { useGetLatestProgressQuery } from '@/app/services/progressesApi';
 import styles from '@/components/ProgressForm/ProgressForm.module.scss';
+import { useRouter } from 'next/router';
 
 function ProgressHeader() {
+    const router = useRouter();
+    const id = router.query.id;
+    const { data: date } = useGetLatestProgressQuery(`taskId=${id}`);
+    const currentDate = new Date();
+    const lastUpdateDate = new Date(date as number);
     return (
         <header className={styles.header}>
             <p>
-                You have <span className={styles.mark}> 2 missed</span> Progress
-                Updates
+                You have{' '}
+                <span className={styles.mark}>
+                    {' '}
+                    {currentDate.getDate() - 1 - lastUpdateDate.getDate()}{' '}
+                    missed
+                </span>{' '}
+                Progress Updates
             </p>
             <p>Lets try to avoid missing updates</p>
         </header>

--- a/src/components/ProgressForm/ProgressHeader.tsx
+++ b/src/components/ProgressForm/ProgressHeader.tsx
@@ -5,9 +5,9 @@ import { useRouter } from 'next/router';
 function ProgressHeader() {
     const router = useRouter();
     const id = router.query.id;
-    const { data: date } = useGetLatestProgressQuery(`taskId=${id}`);
+    const { data } = useGetLatestProgressQuery(`taskId=${id}`);
     const currentDate = new Date();
-    const lastUpdateDate = new Date(date as number);
+    const lastUpdateDate = new Date(data?.date as number);
     return (
         <header className={styles.header}>
             <p>

--- a/src/types/ProgressUpdates.d.ts
+++ b/src/types/ProgressUpdates.d.ts
@@ -30,3 +30,13 @@ interface question {
 export interface formProps {
     questions: Array<question>;
 }
+
+export interface fetchedProgress {
+    id: string;
+    date: number;
+}
+
+export interface taskProgressResponse {
+    message: string;
+    data: Array<fetchedProgress>;
+}


### PR DESCRIPTION
### Issue:
Add RTK query to fetch the latest progress 

### Description:
The Page always showed you have 2 missed updates, Fixed it to show this dynamically based on API call

### Anything you would like to inform the reviewer about:
Tests are on the way in the consecutive PRs

### Dev Tested:
- [x] Yes


### Images/video of the change: (you can see the different values for missed updates in each image)
![image](https://github.com/Real-Dev-Squad/website-status/assets/57758447/88b0275c-e47e-421c-9604-fc5e1638537b)
![image](https://github.com/Real-Dev-Squad/website-status/assets/57758447/294c5e58-d381-44f7-9772-1bd8cde76ec2)


### Follow-up Issues (if any)
Integration Tests for the task progress Feature
https://github.com/Real-Dev-Squad/website-status/issues/594
