### PR TITLE
fixed task card long title (after adding feature-flag)

### DIFF
--- a/src/components/tasks/card/ConditionalLinkWrapper.tsx
+++ b/src/components/tasks/card/ConditionalLinkWrapper.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from 'react';
 import Link from 'next/link';
+import classNames from '@/components/tasks/card/card.module.scss';
 
 interface ConditionalLinkWrapperProps {
     children?: ReactNode;
@@ -21,11 +22,7 @@ export const ConditionalLinkWrapper: FC<ConditionalLinkWrapperProps> = ({
                     pathname: redirectingPath,
                 }}
                 as={`/tasks/${taskId}`}
-                style={{
-                    textDecoration: 'none',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                }}
+                className={classNames.cardTitle}
             >
                 {children}
             </Link>

--- a/src/components/tasks/card/ConditionalLinkWrapper.tsx
+++ b/src/components/tasks/card/ConditionalLinkWrapper.tsx
@@ -21,7 +21,11 @@ export const ConditionalLinkWrapper: FC<ConditionalLinkWrapperProps> = ({
                     pathname: redirectingPath,
                 }}
                 as={`/tasks/${taskId}`}
-                style={{ textDecoration: 'none' }}
+                style={{
+                    textDecoration: 'none',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                }}
             >
                 {children}
             </Link>

--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -61,6 +61,7 @@ $seeMoreTasksShadow: #595959cc;
 }
 
 .cardTitle {
+    text-decoration: none;
     font-size: 1.6rem;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
### Issue: #587

### Description: 
When we add feature flag(?dev=true)  then card long title go outside of the task-card


### Dev Tested:
-  test is not required


### Images/video of the change:

### Before change

https://github.com/Real-Dev-Squad/website-status/assets/107163260/2f568593-a8d5-4afe-acf7-a28b6ab5028c

### After change

https://github.com/Real-Dev-Squad/website-status/assets/107163260/83714b51-7cd6-4eb1-b030-46176db8b0cf

### Responsiveness After using cardTitle css property in anchor tag of ConditionLinkWrapper component

https://github.com/Real-Dev-Squad/website-status/assets/107163260/86910258-ff79-4410-b05c-f056e7363a26






