### PR TITLE
Re-Fractor the task content tab

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_BASE_URL='https://api.realdevsquad.com'
+NEXT_PUBLIC_BASE_URL='https://staging-api.realdevsquad.com'
 NEXT_PUBLIC_GITHUB_IMAGE_URL='https://raw.githubusercontent.com/Real-Dev-Squad/website-static/main/members'
 NEXT_PUBLIC_API_MOCKING='OFF'
 

--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_BASE_URL='https://staging-api.realdevsquad.com'
+NEXT_PUBLIC_BASE_URL='https://api.realdevsquad.com'
 NEXT_PUBLIC_GITHUB_IMAGE_URL='https://raw.githubusercontent.com/Real-Dev-Squad/website-static/main/members'
 NEXT_PUBLIC_API_MOCKING='OFF'
 

--- a/__tests__/Unit/Components/Tabs/Tab.test.tsx
+++ b/__tests__/Unit/Components/Tabs/Tab.test.tsx
@@ -1,12 +1,13 @@
 import Tabs from '@/components/Tabs';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Tab, TABS } from '@/interfaces/task.type';
+import { COMPLETED, DONE, AVAILABLE, UNASSINGED } from '@/constants/constants';
 
 function changeName(name: string) {
-    if (name === 'COMPLETED') {
-        return 'DONE';
-    } else if (name === 'AVAILABLE') {
-        return 'UNASSINGED';
+    if (name === COMPLETED) {
+        return DONE;
+    } else if (name === AVAILABLE) {
+        return UNASSINGED;
     } else {
         return name.split('_').join(' ');
     }

--- a/__tests__/Unit/Components/Tabs/Tab.test.tsx
+++ b/__tests__/Unit/Components/Tabs/Tab.test.tsx
@@ -2,6 +2,16 @@ import Tabs from '@/components/Tabs';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Tab, TABS } from '@/interfaces/task.type';
 
+function changeName(name: string) {
+    if (name === 'COMPLETED') {
+        return 'DONE';
+    } else if (name === 'AVAILABLE') {
+        return 'UNASSINGED';
+    } else {
+        return name.split('_').join(' ');
+    }
+}
+
 describe('Tabs Component', () => {
     const onSelectMock = jest.fn();
 
@@ -38,7 +48,7 @@ describe('Tabs Component', () => {
                 onSelect={onSelectMock}
             />
         );
-        const completedBtn = screen.getByRole('button', { name: /COMPLETED/i });
+        const completedBtn = screen.getByRole('button', { name: /DONE/i });
         expect(completedBtn).toHaveClass('active');
     });
 
@@ -52,9 +62,7 @@ describe('Tabs Component', () => {
         );
         const presentTabs = screen.getAllByRole('button');
         for (let i = 0; i < presentTabs.length; i++) {
-            expect(presentTabs[i].textContent).toBe(
-                TABS[i].split('_').join(' ')
-            );
+            expect(presentTabs[i].textContent).toBe(changeName(TABS[i]));
         }
     });
 });

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,5 +1,6 @@
 import styles from '@/components/Tabs/Tabs.module.scss';
 import { Tab } from '@/interfaces/task.type';
+import { COMPLETED, DONE, AVAILABLE, UNASSINGED } from '@/constants/constants';
 
 type TabsProps = {
     tabs: Tab[];
@@ -7,10 +8,10 @@ type TabsProps = {
     activeTab: Tab;
 };
 function changeName(name: string) {
-    if (name === 'COMPLETED') {
-        return 'DONE';
-    } else if (name === 'AVAILABLE') {
-        return 'UNASSINGED';
+    if (name === COMPLETED) {
+        return DONE;
+    } else if (name === AVAILABLE) {
+        return UNASSINGED;
     } else {
         return name.split('_').join(' ');
     }

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -6,6 +6,15 @@ type TabsProps = {
     onSelect: (tab: Tab) => void;
     activeTab: Tab;
 };
+function changeName(name: string) {
+    if (name === 'COMPLETED') {
+        return 'DONE';
+    } else if (name === 'AVAILABLE') {
+        return 'UNASSINGED';
+    } else {
+        return name.split('_').join(' ');
+    }
+}
 
 const Tabs = ({ tabs, onSelect, activeTab }: TabsProps) => (
     <>
@@ -17,7 +26,7 @@ const Tabs = ({ tabs, onSelect, activeTab }: TabsProps) => (
                     activeTab === tab ? styles.active : ''
                 }`}
             >
-                {tab.split('_').join(' ')}
+                {changeName(tab)}
             </button>
         ))}
     </>

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -25,7 +25,7 @@ export const TasksContent = () => {
     const { isEditMode } = useEditMode();
     const isUserAuthorized = useContext(isUserAuthorizedContext);
     const isEditable = isUserAuthorized && isEditMode;
-    const [activeTab, setActiveTab] = useState(Tab.ASSIGNED);
+    const [activeTab, setActiveTab] = useState(Tab.IN_PROGRESS);
     // TODO: the below code should removed when mutation for updating tasks is implemented
     const [filteredTask, setFilteredTask] = useState<any>([]);
     // TODO: the below code should removed when mutation for updating tasks is implemented

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,1 +1,5 @@
 export const MAX_SEARCH_RESULTS = 1;
+export const COMPLETED = 'COMPLETED';
+export const DONE = 'DONE';
+export const AVAILABLE = 'AVAILABLE';
+export const UNASSINGED = 'UNASSINGED';

--- a/src/interfaces/task.type.ts
+++ b/src/interfaces/task.type.ts
@@ -34,14 +34,14 @@ type task = {
 };
 
 enum Tab {
-    ASSIGNED = 'ASSIGNED',
-    COMPLETED = 'COMPLETED',
-    AVAILABLE = 'AVAILABLE',
     IN_PROGRESS = 'IN_PROGRESS',
+    ASSIGNED = 'ASSIGNED',
+    AVAILABLE = 'AVAILABLE',
     NEEDS_REVIEW = 'NEEDS_REVIEW',
     IN_REVIEW = 'IN_REVIEW',
     VERIFIED = 'VERIFIED',
     MERGED = 'MERGED',
+    COMPLETED = 'COMPLETED',
 }
 
 const TABS = Object.values(Tab);


### PR DESCRIPTION
### Issue:
https://github.com/Real-Dev-Squad/website-status/issues/608
### Description:
Rearrange the task content tab and also rename some task content

Arrangements should be in this form -
IN_PROGRESS -> ASSIGNED -> AVAILABLE -> NEEDS_REVIEW -> IN_REVIEW ->VERIFIED -> MERGED -> COMPLETED

Tabs that need to be renamed -
AVAILABLE - UNASSIGNED
COMPLETED- DONE

### Dev Tested:
- [x] Yes


### Images/video of the change:

Before change - 
![image](https://github.com/Real-Dev-Squad/website-status/assets/82165483/24069c86-8570-4daf-bfbb-45aea329a2b2)

After change - 

https://github.com/Real-Dev-Squad/website-status/assets/82165483/623071db-7e1c-499a-85c4-5f8769817fc0

Due to Errors and in-consistency in files, I have closed this PR 
https://github.com/Real-Dev-Squad/website-status/pull/623
