### PR TITLE
fix styles of progress form to be responsive on small screens

### DIFF
--- a/src/components/ProgressForm/ProgressForm.module.scss
+++ b/src/components/ProgressForm/ProgressForm.module.scss
@@ -12,15 +12,15 @@ $section-padding-top-bottom: $base-unit * 30;
 $section-padding-left-right: $base-unit * 25;
 
 .header {
+    width: 60%;
     margin: $diff-margin auto;
     background-color: $color-blue;
     color: $color-white;
-    padding-top: $section-padding-top-bottom;
-    padding-bottom: $section-padding-top-bottom;
-    padding-left: $section-padding-left-right;
-    width: 95%;
     border: 1px solid $color-red;
     font-size: $base-unit * 4;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .mark {
@@ -30,13 +30,13 @@ $section-padding-left-right: $base-unit * 25;
 
 .container {
     margin: $diff-margin auto;
-    padding: 0 $section-padding-left-right;
+    width: 60%;
 }
 
 .formHeading {
     color: $color-blue;
     margin: $diff-margin auto;
-    padding: 0 $section-padding-left-right;
+    font-size: $base-unit * 10;
 }
 
 .date {
@@ -55,11 +55,11 @@ $section-padding-left-right: $base-unit * 25;
 }
 
 .input {
-    width: 90%;
     display: block;
     resize: none;
     padding: $base-unit * 2;
     border-radius: $base-unit * 2;
+    width: 100%;
 }
 
 .buttonEnabled {
@@ -79,4 +79,13 @@ $section-padding-left-right: $base-unit * 25;
     border-radius: $base-unit * 2;
     margin-bottom: $diff-margin;
     font-size: $base-font-size * 4;
+}
+
+@media (max-width: 770px) {
+    .container {
+        width: 90%;
+    }
+    .header {
+        width: 90%;
+    }
 }

--- a/src/components/ProgressForm/ProgressForm.module.scss
+++ b/src/components/ProgressForm/ProgressForm.module.scss
@@ -11,7 +11,7 @@ $similar-margin: $base-unit * 8;
 $section-padding-top-bottom: $base-unit * 30;
 $section-padding-left-right: $base-unit * 25;
 
-.header {
+.banner {
     width: 60%;
     margin: $diff-margin auto;
     background-color: $color-blue;
@@ -85,7 +85,7 @@ $section-padding-left-right: $base-unit * 25;
     .container {
         width: 90%;
     }
-    .header {
+    .banner {
         width: 90%;
     }
 }

--- a/src/components/ProgressForm/ProgressHeader.tsx
+++ b/src/components/ProgressForm/ProgressHeader.tsx
@@ -2,7 +2,7 @@ import styles from '@/components/ProgressForm/ProgressForm.module.scss';
 
 function ProgressHeader() {
     return (
-        <header className={styles.header}>
+        <header className={styles.banner}>
             <p>
                 You have <span className={styles.mark}> 2 missed</span> Progress
                 Updates

--- a/src/components/ProgressForm/ProgressLayout.tsx
+++ b/src/components/ProgressForm/ProgressLayout.tsx
@@ -14,8 +14,8 @@ function ProgressLayout() {
         <>
             <NavBar />
             <ProgressHeader />
-            <h1 className={styles.formHeading}>Task Updates</h1>
             <section className={styles.container}>
+                <h1 className={styles.formHeading}>Task Updates</h1>
                 <h2 className={styles.date}>On {getCurrentDate()}</h2>
                 <ProgressForm questions={questions} />
             </section>


### PR DESCRIPTION
### Issue:
Progress form is not responsive, and looks very odd on small screens

### Description:
The margins and padding added to the form break it in mobile view. fixed the form to look consistent and appealing to the user even in mobile phones.

### Dev Tested:
- [x] Yes


### Images/video of the change:

#### Before change

![image](https://github.com/Real-Dev-Squad/website-status/assets/57758447/b05d93b2-b2f4-4356-bf89-5995caa4ec31)

#### After change

![image](https://github.com/Real-Dev-Squad/website-status/assets/57758447/9b6d22bc-8405-48f1-bd14-71501bae0a77)
