### PR TITLE
Fix/Style/Refactor : Divider between the status header links, font-size

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -8,29 +8,25 @@
 }
 
 .link {
-    padding: 0.6rem;
+    margin: 0.2rem;
+    border: none;
+    border-right: 1.6px solid var(--toastify-text-color-light);
+    padding: 0 0.8rem;
+    min-width: 4rem;
+    height: 1.5rem;
+    font-size: 1rem;
     text-decoration: none;
     font-weight: 700;
     color: #041484;
     cursor: pointer;
     background: none;
-    border: none;
     position: relative;
-
-    &::after {
-        content: '';
-        position: absolute;
-        height: 1rem;
-        width: 2px;
-        right: 0;
-        background-color: #00000077;
-    }
 }
 
 // Hide | for the last elements
 .header a:last-child {
-    .link::after {
-        display: none;
+    .link {
+        border-right: none;
     }
 }
 


### PR DESCRIPTION
### Issue:
https://github.com/Real-Dev-Squad/website-status/issues/659
### Description:
Replaced the PIPE(|) Character with CSS divider

### Anything you would like to inform the reviewer about:

### Dev Tested:
- [x] Yes

### Images/video of the change:
### Before : 
![image](https://github.com/Real-Dev-Squad/website-status/assets/53934353/f856b67c-72d8-42d8-8abf-76603f1238c8)

### After :
![image](https://github.com/Real-Dev-Squad/website-status/assets/53934353/4ec9a4b3-77a4-47f3-a62f-96bb5c03de5c)


### Follow-up Issues (if any)