### PR TITLE
add /tasks route for tasks page

### DIFF
--- a/__tests__/Unit/Components/Header/Header.test.tsx
+++ b/__tests__/Unit/Components/Header/Header.test.tsx
@@ -8,7 +8,7 @@ describe('Header without dev mode', () => {
     it('should have Tasks category', () => {
         useRouter.mockImplementation(() => {
             return {
-                pathname: '/',
+                pathname: '/tasks',
                 query: {},
             };
         });
@@ -226,7 +226,7 @@ describe('Header with dev mode', () => {
     it('should have Tasks category', () => {
         useRouter.mockImplementation(() => {
             return {
-                pathname: '/',
+                pathname: '/tasks',
                 query: { dev: true },
             };
         });

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,15 @@
 module.exports = {
-	images: {
-		domains: ['raw.githubusercontent.com', 'res.cloudinary.com'],
-	},
+    images: {
+        domains: ['raw.githubusercontent.com', 'res.cloudinary.com'],
+    },
+
+    async redirects() {
+        return [
+            {
+                source: '/',
+                destination: '/tasks',
+                permanent: true,
+            },
+        ];
+    },
 };

--- a/src/constants/header-categories.ts
+++ b/src/constants/header-categories.ts
@@ -1,8 +1,8 @@
 export const headerCategories = [
     {
         title: 'Tasks',
-        refURL: '/',
-        pathName: '/',
+        refURL: '/tasks',
+        pathName: '/tasks',
     },
     {
         title: 'Issues',

--- a/src/pages/tasks/index.tsx
+++ b/src/pages/tasks/index.tsx
@@ -4,7 +4,7 @@ import Layout from '@/components/Layout';
 import classNames from '@/styles/tasks.module.scss';
 import { TasksContent } from '@/components/tasks/TasksContent';
 
-const Index: FC = () => {
+const Task: FC = () => {
     return (
         <Layout>
             <Head title="Tasks" />
@@ -16,4 +16,4 @@ const Index: FC = () => {
     );
 };
 
-export default Index;
+export default Task;

--- a/src/pages/tasks/index.tsx
+++ b/src/pages/tasks/index.tsx
@@ -4,7 +4,7 @@ import Layout from '@/components/Layout';
 import classNames from '@/styles/tasks.module.scss';
 import { TasksContent } from '@/components/tasks/TasksContent';
 
-const Task: FC = () => {
+const Tasks: FC = () => {
     return (
         <Layout>
             <Head title="Tasks" />
@@ -16,4 +16,4 @@ const Task: FC = () => {
     );
 };
 
-export default Task;
+export default Tasks;


### PR DESCRIPTION
### Issue: #672 

### Description:
Change make `/tasks` route to get tasks data instead of `/`

### Dev Tested:
- [x] Yes


### Images/video of the change:
<img width="262" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/34452139/a3e3ca5c-8ed0-44d5-a7c2-5dd8ad82cadb">


closes #672 