### PR TITLE
fix: overflow of the issues card

### DIFF
--- a/src/components/issues/Card.module.scss
+++ b/src/components/issues/Card.module.scss
@@ -102,7 +102,7 @@ $card-text: #78716c;
 .card__body {
     width: 100%;
     color: black;
-
+    overflow: auto;
     h1 {
         font-size: 1.2rem;
     }


### PR DESCRIPTION
### Issue:
https://github.com/Real-Dev-Squad/website-status/issues/681
### Description: 
Issue page break when search on mobile. Add overflow:auto in the Card.modules.css and resolved the overflowing of the card

### Anthing you would like to inform the reviewer about:

### Dev Tested:
- [x] Yes 


### Images/video of the change:
**Before**
![image](https://github.com/Real-Dev-Squad/website-status/assets/80218238/14ae4056-188b-4fe8-b29a-0218bc6f1658)

**After**
![image](https://github.com/Real-Dev-Squad/website-status/assets/80218238/6969c32c-2412-4069-958d-5f6338eecfae)

### Follow-up Issues (if any)
