### PR TITLE
Fix : banner responsiveness for the task progress and standup feature

### DIFF
--- a/src/components/ProgressForm/ProgressForm.module.scss
+++ b/src/components/ProgressForm/ProgressForm.module.scss
@@ -10,7 +10,12 @@ $diff-margin: $base-unit * 15;
 $similar-margin: $base-unit * 8;
 $section-padding-top-bottom: $base-unit * 30;
 $section-padding-left-right: $base-unit * 25;
+$theme-inputFieldBorder: #d1d5db;
+$theme-focusHighlight: #1c64f2;
 
+.progressUpdateContainer {
+    padding: 2rem;
+}
 .mark {
     color: $color-red;
     text-decoration: underline;
@@ -23,13 +28,11 @@ $section-padding-left-right: $base-unit * 25;
 
 .formHeading {
     color: $color-blue;
-    margin: $diff-margin auto;
-    font-size: $base-unit * 10;
+    font-size: $base-unit * 8;
 }
 
 .date {
     opacity: 50%;
-    margin: $diff-margin auto;
 }
 
 .inputComponent {
@@ -37,17 +40,26 @@ $section-padding-left-right: $base-unit * 25;
 }
 
 .label {
-    font-size: $base-font-size * 5;
+    font-size: $base-font-size * 4.2;
     display: block;
-    margin-bottom: $similar-margin;
+    margin-bottom: $similar-margin * 1/2;
+    color: var(--toastify-spinner-color);
 }
 
 .input {
+    border: 2px solid $theme-inputFieldBorder;
     display: block;
     resize: none;
     padding: $base-unit * 2;
     border-radius: $base-unit * 2;
     width: 100%;
+    font-size: 1rem;
+    color: var(--toastify-spinner-color);
+}
+
+.input:focus {
+    border: 1px solid $theme-focusHighlight;
+    outline: none;
 }
 
 .buttonEnabled {
@@ -59,10 +71,16 @@ $section-padding-left-right: $base-unit * 25;
     font-size: $base-font-size * 4;
 }
 
+.buttonDisabled,
+.buttonEnabled {
+    border: none;
+    width: 14rem;
+    color: var(--toastify-spinner-color);
+}
+
 .buttonDisabled {
     cursor: not-allowed;
     background-color: $color-disabled;
-    color: $color-black;
     padding: $base-unit * 4 $base-unit * 8;
     border-radius: $base-unit * 2;
     margin-bottom: $diff-margin;

--- a/src/components/ProgressForm/ProgressLayout.tsx
+++ b/src/components/ProgressForm/ProgressLayout.tsx
@@ -20,15 +20,17 @@ const ProgressLayout: FC = () => {
     return (
         <>
             <NavBar />
-            <ProgressHeader
-                totalMissedUpdates={totalMissedUpdates}
-                updateType="Progress"
-            />
-            <section className={styles.container}>
-                <h1 className={styles.formHeading}>Task Updates</h1>
-                <h2 className={styles.date}>On {getCurrentDate()}</h2>
-                <ProgressForm questions={questions} />
-            </section>
+            <div className={styles.progressUpdateContainer}>
+                <ProgressHeader
+                    totalMissedUpdates={totalMissedUpdates}
+                    updateType="Progress"
+                />
+                <section className={styles.container}>
+                    <h1 className={styles.formHeading}>Task Updates</h1>
+                    <h2 className={styles.date}>On {getCurrentDate()}</h2>
+                    <ProgressForm questions={questions} />
+                </section>
+            </div>
         </>
     );
 };

--- a/src/components/standup/standupContainer.module.scss
+++ b/src/components/standup/standupContainer.module.scss
@@ -9,31 +9,20 @@ $theme-inputFieldBorder: #d1d5db;
 $theme-nonActiveButtonBackground: #e5e7eb;
 $radius: 0.5rem;
 
-.standupContainer {
+.bannerContainer {
     display: flex;
-    flex-direction: column;
-    width: 100%;
-    align-items: center;
     justify-content: center;
+    align-items: center;
+    width: 100%;
 }
 
 .progressBanner {
     background-color: $theme-primaryBackground;
-    width: 84%;
-    height: 12%;
     color: $theme-whiteColor;
     padding: 2rem;
     border-radius: $radius;
-}
-
-.bannerContainer {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    width: 100%;
     margin-top: 2rem;
-    margin-left: 8.2rem;
+    width: 100%;
 }
 
 .bannerPara {
@@ -49,22 +38,25 @@ $radius: 0.5rem;
 }
 
 .standupUpdateContainer {
-    width: 50%;
-    margin-top: 2rem;
-}
-
-.standupForm {
-    margin-top: 2.2rem;
+    border: 1px solid var(--toastify-spinner-color);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    text-align: center;
+    border-radius: 1rem;
+    margin-top: 4rem;
 }
 
 .standupTitle {
     color: $theme-secondaryBackground;
     font-family: 'Inter', sans-serif;
     font-size: 2.2rem;
-    padding-left: 0.8rem;
 }
 
 .formFields {
+    text-align: left;
     margin-bottom: 1.25rem;
     border: none;
 }
@@ -82,9 +74,7 @@ $radius: 0.5rem;
     border: 1px solid $theme-inputFieldBorder;
     background: $theme-whiteColor;
     padding: 1rem;
-    font-weight: 400;
-    font-size: 0.8rem;
-    line-height: 150%;
+    font-size: 1rem;
     font-family: 'Inter', sans-serif;
     margin: 0.8rem 0 2.4rem 0;
 }
@@ -95,17 +85,15 @@ $radius: 0.5rem;
 }
 
 .submitButton {
+    margin: 1rem;
     width: 14rem;
     height: 4rem;
     border-radius: $radius;
-    font-weight: 400;
-    font-size: 0.8rem;
-    line-height: 150%;
+    font-size: 1.2rem;
     font-family: 'Inter', sans-serif;
     border: none;
     cursor: pointer;
-    letter-spacing: 0.8px;
-    margin-left: 1rem;
+    color: var(--toastify-spinner-color);
 }
 
 .submitButton:active {
@@ -122,39 +110,8 @@ $radius: 0.5rem;
     background: $theme-nonActiveButtonBackground;
 }
 
-@media (max-width: 946px) {
-    .standupUpdateContainer {
-        width: 76%;
-    }
-}
-
-@media (max-width: 600px) {
-    .standupBanner {
-        width: 100%;
-        padding: 2rem;
-        text-align: center;
-    }
-
-    .bannerPara {
-        font-size: 1rem;
-        word-wrap: break-word;
-    }
-
+@media (max-width: 980px) {
     .standupUpdateContainer {
         width: 100%;
-        margin-top: 0.24rem;
-    }
-
-    .standupTitle {
-        font-size: 1.6rem;
-    }
-
-    .updateHeading {
-        font-size: 1rem;
-    }
-
-    .submitButton {
-        width: 10rem;
-        height: 2.6rem;
     }
 }

--- a/src/components/standup/standupContainer.module.scss
+++ b/src/components/standup/standupContainer.module.scss
@@ -10,9 +10,6 @@ $theme-nonActiveButtonBackground: #e5e7eb;
 $radius: 0.5rem;
 
 .bannerContainer {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     width: 100%;
 }
 
@@ -38,18 +35,17 @@ $radius: 0.5rem;
 }
 
 .standupUpdateContainer {
-    border: 1px solid var(--toastify-spinner-color);
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     width: 100%;
-    text-align: center;
     border-radius: 1rem;
     margin-top: 4rem;
 }
 
 .standupTitle {
+    margin-left: 1rem;
     color: $theme-secondaryBackground;
     font-family: 'Inter', sans-serif;
     font-size: 2.2rem;
@@ -57,7 +53,6 @@ $radius: 0.5rem;
 
 .formFields {
     text-align: left;
-    margin-bottom: 1.25rem;
     border: none;
 }
 
@@ -71,7 +66,7 @@ $radius: 0.5rem;
     height: 4rem;
     width: 100%;
     border-radius: $radius;
-    border: 1px solid $theme-inputFieldBorder;
+    border: 2px solid $theme-inputFieldBorder;
     background: $theme-whiteColor;
     padding: 1rem;
     font-size: 1rem;
@@ -85,7 +80,7 @@ $radius: 0.5rem;
 }
 
 .submitButton {
-    margin: 1rem;
+    margin-left: 1rem;
     width: 14rem;
     height: 4rem;
     border-radius: $radius;


### PR DESCRIPTION
 ### Issue :  
- #666 

### Description:
The progress banner and the standup update form are now responsive with a proper layout. 

### Images/video of the change :

### Before :
### Progress Update : 
![image](https://github.com/Real-Dev-Squad/website-status/assets/53934353/30212174-03c6-4dd4-8612-6dd402d11c3d)

### Standup Update : 
![image](https://github.com/Real-Dev-Squad/website-status/assets/53934353/4538f950-d669-4cac-ac1a-0214c033197b)

### After : 
### Progress Update : 
https://github.com/Real-Dev-Squad/website-status/assets/53934353/e08d5d36-ceb3-4805-a211-8fec0db1bdaa

### Standup Update : 
https://github.com/Real-Dev-Squad/website-status/assets/53934353/c6f05db6-45c3-4b90-8f40-d784fcf7abcb

###  Dev Tested:
- [x] Yes