### PR TITLE
Revert "fixed editing of title field"

### DIFF
--- a/src/components/tasks/card/index.tsx
+++ b/src/components/tasks/card/index.tsx
@@ -143,7 +143,7 @@ const Card: FC<Props> = ({
     ) {
         if (event.key === 'Enter') {
             const toChange: any = cardDetails;
-            toChange[changedProperty] = stripHtml(event.target.innerHTML);
+            toChange[changedProperty] = stripHtml(assigneeName);
 
             if (
                 changedProperty === 'endsOn' ||


### PR DESCRIPTION
Reverts Real-Dev-Squad/website-status#706

replacing assigneeName with event.target.innerHTML is sending empty string which throws an error of 'assignee' cannot be empty.

