### PR TITLE
Fix user loggedin from  mine tab

### DIFF
--- a/src/hooks/useAuthenticated.ts
+++ b/src/hooks/useAuthenticated.ts
@@ -33,7 +33,7 @@ const useAuthenticated = (): userDetails => {
 
     useEffect(() => {
         setUserDetails();
-    }, []);
+    }, [isSuccess]);
     return { userData, isLoggedIn, isLoading };
 };
 


### PR DESCRIPTION
### Issue:

close #713 

### Description:
Currently, mine tab can't able to fetch user details to mark it as logged in so to set it as logged in we have to pass isSuccess as dependent in useeffect 

### Anything you would like to inform the reviewer about:

### Dev Tested:
- [ ] Yes


### Images/video of the change:


### Follow-up Issues (if any)
