### PR TITLE
FEATURE: Add intersection observer for fetching task

### DIFF
--- a/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
@@ -10,6 +10,11 @@ import { noTasksFoundHandler } from '../../../../__mocks__//handlers/tasks.handl
 import { TABS } from '@/interfaces/task.type';
 import { getChangedStatusName } from '@/utils/getChangedStatusName';
 
+jest.mock('@/hooks/useIntersection', () => ({
+    __esModule: true,
+    default: jest.fn(),
+}));
+
 const server = setupServer(...handlers);
 
 beforeAll(() => {
@@ -111,60 +116,6 @@ describe('tasks content', () => {
             'Design and develop an online booking system'
         );
         expect(task).toBeInTheDocument();
-    });
-
-    test('load more button is disabled when there are no more tasks to load', async () => {
-        server.use(noTasksFoundHandler);
-        renderWithRouter(
-            <Provider store={store()}>
-                <TasksContent dev={true} />
-            </Provider>,
-            { query: { dev: 'true' } }
-        );
-        await screen.findByTestId('tabs');
-
-        const loadMoreButton = screen.getByRole('button', {
-            name: /load more/i,
-        });
-        expect(loadMoreButton).toBeDisabled();
-    });
-
-    test('load more button is enabled when there are more tasks to load', async () => {
-        renderWithRouter(
-            <Provider store={store()}>
-                <TasksContent dev={true} />
-            </Provider>,
-            { query: { dev: 'true' } }
-        );
-        await screen.findByTestId('tabs');
-
-        const loadMoreButton = screen.getByRole('button', {
-            name: /load more/i,
-        });
-        expect(loadMoreButton).toBeEnabled();
-    });
-
-    test('fetch more tasks when load more button is clicked', async () => {
-        const { findByText } = renderWithRouter(
-            <Provider store={store()}>
-                <TasksContent dev={true} />
-            </Provider>,
-            { query: { dev: 'true', section: 'available' } }
-        );
-        await screen.findByTestId('tabs');
-        const task = await findByText(
-            'Design and develop an online booking system'
-        );
-        expect(task).toBeInTheDocument();
-        const loadMoreButton = await screen.getByRole('button', {
-            name: /load more/i,
-        });
-        expect(loadMoreButton).toBeEnabled();
-        fireEvent.click(loadMoreButton);
-        const task2 = await findByText(
-            'Design and develop an online booking system'
-        );
-        expect(task2).toBeInTheDocument();
     });
 
     test('Selecting a tab pushes into query params', async () => {

--- a/__tests__/Unit/hooks/useIntersection.ts.test.tsx
+++ b/__tests__/Unit/hooks/useIntersection.ts.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-hooks';
+import useIntersection from './../../../src/hooks/useIntersection';
+import { MutableRefObject } from 'react';
+
+const mockIntersectionObserver = jest.fn();
+mockIntersectionObserver.mockReturnValue({
+    observe: () => null,
+    unobserve: () => null,
+    disconnect: () => null,
+});
+
+describe('useIntersection', () => {
+    let loadingRef: MutableRefObject<HTMLDivElement | null>;
+    let bottomBoundaryRef: MutableRefObject<HTMLDivElement | null>;
+    let onLoadMore: jest.Mock<any, any>;
+
+    beforeEach(() => {
+        loadingRef = { current: document.createElement('div') };
+        bottomBoundaryRef = { current: document.createElement('div') };
+        onLoadMore = jest.fn();
+        window.IntersectionObserver = mockIntersectionObserver;
+    });
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should observe the loadingRef element', () => {
+        renderHook(() =>
+            useIntersection(loadingRef, bottomBoundaryRef, onLoadMore)
+        );
+        expect(mockIntersectionObserver).toHaveBeenCalledTimes(1);
+        expect(mockIntersectionObserver).toHaveBeenCalledWith(
+            expect.any(Function),
+            { root: null, rootMargin: '0px', threshold: 0 }
+        );
+    });
+
+    it('should add and remove event listener for the scroll event', () => {
+        const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+        const removeEventListenerSpy = jest.spyOn(
+            window,
+            'removeEventListener'
+        );
+        const { unmount } = renderHook(() =>
+            useIntersection(loadingRef, bottomBoundaryRef, onLoadMore)
+        );
+        expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+        expect(addEventListenerSpy).toHaveBeenCalledWith(
+            'scroll',
+            expect.any(Function)
+        );
+        unmount();
+        expect(removeEventListenerSpy).toHaveBeenCalledTimes(1);
+        expect(removeEventListenerSpy).toHaveBeenCalledWith(
+            'scroll',
+            expect.any(Function)
+        );
+        addEventListenerSpy.mockRestore();
+        removeEventListenerSpy.mockRestore();
+    });
+
+    it('should call onLoadMore when scroll reaches the bottom boundary', () => {
+        const handleScroll = jest.fn();
+        const addEventListenerSpy = jest
+            .spyOn(window, 'addEventListener')
+            .mockImplementation((event, cb) => {
+                if (event === 'scroll') {
+                    handleScroll.mockImplementation(cb as any);
+                }
+            });
+        renderHook(() =>
+            useIntersection(loadingRef, bottomBoundaryRef, onLoadMore)
+        );
+        const bottomBoundaryRect = {
+            top: window.innerHeight,
+        };
+        Object.defineProperty(
+            bottomBoundaryRef.current,
+            'getBoundingClientRect',
+            {
+                value: () => bottomBoundaryRect,
+            }
+        );
+        handleScroll();
+        expect(onLoadMore).toHaveBeenCalledTimes(1);
+        addEventListenerSpy.mockRestore();
+    });
+});

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -1,3 +1,4 @@
+import { ElementRef } from 'react';
 import classNames from '@/styles/tasks.module.scss';
 import { useGetAllTasksQuery } from '@/app/services/tasksApi';
 import task, { TABS, Tab, TabTasksData } from '@/interfaces/task.type';
@@ -66,6 +67,8 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
         MERGED: [],
         COMPLETED: [],
     });
+    const loadingRef = useRef<ElementRef<'div'>>(null);
+    const bottomBoundaryRef = useRef<ElementRef<'div'>>(null);
 
     const {
         data: tasksData = { tasks: [], next: '' },
@@ -109,9 +112,6 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
             setLoadedTasks(newTasks);
         }
     }, [tasksData.tasks]);
-
-    const loadingRef = useRef<HTMLDivElement | null>(null);
-    const bottomBoundaryRef = useRef<HTMLDivElement | null>(null);
 
     useIntersection(loadingRef, bottomBoundaryRef, fetchMoreTasks);
 

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -1,7 +1,7 @@
 import classNames from '@/styles/tasks.module.scss';
 import { useGetAllTasksQuery } from '@/app/services/tasksApi';
 import task, { TABS, Tab, TabTasksData } from '@/interfaces/task.type';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
     NO_TASKS_FOUND_MESSAGE,
     TASKS_FETCH_ERROR_MESSAGE,
@@ -13,6 +13,7 @@ import { getActiveTab } from '@/utils/getActiveTab';
 
 import { Select } from '../Select';
 import { getChangedStatusName } from '@/utils/getChangedStatusName';
+import useIntersection from '@/hooks/useIntersection';
 
 type RenderTaskListProps = {
     tab: string;
@@ -109,6 +110,11 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
         }
     }, [tasksData.tasks]);
 
+    const loadingRef = useRef<HTMLDivElement | null>(null);
+    const bottomBoundaryRef = useRef<HTMLDivElement | null>(null);
+
+    useIntersection(loadingRef, bottomBoundaryRef, fetchMoreTasks);
+
     if (isLoading) return <p>Loading...</p>;
 
     if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
@@ -149,15 +155,10 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
                     tasks={loadedTasks[selectedTab]}
                 />
             </div>
-            {dev && (
-                <button
-                    className={classNames.loadMoreButton}
-                    onClick={fetchMoreTasks}
-                    disabled={!tasksData.next}
-                >
-                    {isFetching ? 'Loading...' : 'Load More'}
-                </button>
-            )}
+
+            <div ref={loadingRef}>{isFetching ? 'Loading...' : null}</div>
+
+            <div ref={bottomBoundaryRef}></div>
         </div>
     );
 };

--- a/src/hooks/useIntersection.ts
+++ b/src/hooks/useIntersection.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+const useIntersection = (
+    loadingRef: React.MutableRefObject<HTMLDivElement | null>,
+    bottomBoundaryRef: React.MutableRefObject<HTMLDivElement | null>,
+    onLoadMore: () => void
+) => {
+    const [isIntersecting, setIsIntersecting] = useState(false);
+
+    useEffect(() => {
+        const options = {
+            root: null,
+            rootMargin: '0px',
+            threshold: 0,
+        };
+
+        const observer = new IntersectionObserver(([entry]) => {
+            setIsIntersecting(entry.isIntersecting);
+        }, options);
+
+        if (loadingRef.current) {
+            observer.observe(loadingRef.current);
+        }
+
+        return () => {
+            if (loadingRef.current) {
+                observer.unobserve(loadingRef.current);
+            }
+        };
+    }, [loadingRef]);
+
+    useEffect(() => {
+        if (isIntersecting) {
+            onLoadMore();
+        }
+    }, [isIntersecting, onLoadMore]);
+
+    useEffect(() => {
+        const handleScroll = () => {
+            const bottomBoundaryRect =
+                bottomBoundaryRef.current?.getBoundingClientRect();
+            if (
+                bottomBoundaryRect &&
+                bottomBoundaryRect.top <= window.innerHeight
+            ) {
+                onLoadMore();
+            }
+        };
+
+        window.addEventListener('scroll', handleScroll);
+        return () => {
+            window.removeEventListener('scroll', handleScroll);
+        };
+    }, [bottomBoundaryRef, onLoadMore]);
+};
+
+export default useIntersection;

--- a/src/hooks/useIntersection.ts
+++ b/src/hooks/useIntersection.ts
@@ -1,18 +1,18 @@
 import { useEffect, useState } from 'react';
+
 const useIntersection = (
     loadingRef: React.MutableRefObject<HTMLDivElement | null>,
     bottomBoundaryRef: React.MutableRefObject<HTMLDivElement | null>,
     onLoadMore: () => void
 ) => {
     const [isIntersecting, setIsIntersecting] = useState(false);
+    const options = {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0,
+    };
 
     useEffect(() => {
-        const options = {
-            root: null,
-            rootMargin: '0px',
-            threshold: 0,
-        };
-
         const observer = new IntersectionObserver(([entry]) => {
             setIsIntersecting(entry.isIntersecting);
         }, options);


### PR DESCRIPTION
### Closes: #769 

### Description:
As part of this implementation, we will use the Intersection Observer API to automatically fetch the next task when the user reaches the end of the task list container. This will eliminate the need for the "Load More" button, providing a smoother user experience.

### Anything you would like to inform the reviewer about:

### Dev Tested:
- [x] Yes

### Test Coverage:
![image](https://github.com/Real-Dev-Squad/website-status/assets/70854507/55b1d664-1216-46fe-8a2f-960b04001abf)
![image](https://github.com/Real-Dev-Squad/website-status/assets/70854507/d10b496b-aae7-4536-a270-84d3a8b70b90)

### Images/video of the change:
https://github.com/Real-Dev-Squad/website-status/assets/70854507/fc0ae344-ad0b-4e61-bd4c-21033bcd474e

### Follow-up Issues (if any)
