### PR TITLE
quick fix: changed hardcoded vlaue in handleChange to event.target.value

### DIFF
--- a/src/components/tasks/card/index.tsx
+++ b/src/components/tasks/card/index.tsx
@@ -134,7 +134,7 @@ const Card: FC<Props> = ({
     ) {
         if (event.key === 'Enter') {
             const toChange: any = cardDetails;
-            toChange[changedProperty] = stripHtml(assigneeName);
+            toChange[changedProperty] = stripHtml(event.target.value);
 
             if (
                 changedProperty === 'endsOn' ||


### PR DESCRIPTION
quick fix: changed hardcoded vlaue in handleChange to event.target.value.

Our handleChange function is used to edit the details on card component such as title, date, assigneeName. 
Earlier it was hardcoded to assigneeName, so even we change title it takes assigneeName as value.