### PR TITLE
Prevent Hello with empty profile rendering in navbar when user already loggedin

### DIFF
--- a/__tests__/Unit/Components/Navbar/Navbar.test.tsx
+++ b/__tests__/Unit/Components/Navbar/Navbar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { screen, render, waitFor } from '@testing-library/react';
 import NavBar from '../../../../src/components/navBar';
 import * as authHooks from '@/hooks/useAuthenticated';
 import { renderWithProviders } from '@/test-utils/renderWithProvider';
@@ -90,5 +90,13 @@ describe('Navbar', () => {
         await screen.findAllByTestId('navbar');
         const logo = getByTestId('logo');
         expect(logo).toBeInTheDocument();
+    });
+    test('Sign In With Github button should not render when user is already loggedin', async () => {
+        renderWithProviders(<NavBar />);
+        await waitFor(() => {
+            const loginTextElement = screen.queryByText('Sign In With Github');
+            expect(loginTextElement).not.toBeInTheDocument();
+            screen.debug();
+        });
     });
 });

--- a/__tests__/Unit/Components/Navbar/Navbar.test.tsx
+++ b/__tests__/Unit/Components/Navbar/Navbar.test.tsx
@@ -96,7 +96,6 @@ describe('Navbar', () => {
         await waitFor(() => {
             const loginTextElement = screen.queryByText('Sign In With Github');
             expect(loginTextElement).not.toBeInTheDocument();
-            screen.debug();
         });
     });
 });

--- a/src/components/navBar/index.tsx
+++ b/src/components/navBar/index.tsx
@@ -78,40 +78,44 @@ const NavBar = () => {
                 </ul>
             </div>
             <div className={styles.userProfile}>
-                {!isLoggedIn ? (
-                    <Link href={LOGIN_URL}>
-                        <button className={styles.signInLink}>
-                            Sign In With Github
+                {userData !== undefined ? (
+                    userData ? (
+                        <div
+                            className={styles.userGreet}
+                            onClick={() => setToggleDropdown(!toggleDropdown)}
+                        >
+                            <div className={styles.userGreetMsg}>
+                                Hello, {userData?.first_name}
+                            </div>
                             <Image
-                                className={styles.githubLogo}
-                                src={GITHUB_LOGO}
-                                height="20"
-                                width="20"
-                                alt="GitHub Icon"
+                                className={styles.userProfilePic}
+                                src={
+                                    userData?.picture?.url
+                                        ? `${userData?.picture?.url}`
+                                        : `${DEFAULT_AVATAR}`
+                                }
+                                alt="Profile Pic"
+                                width="32"
+                                height="32"
                             />
-                        </button>
-                    </Link>
-                ) : (
-                    <div
-                        className={styles.userGreet}
-                        onClick={() => setToggleDropdown(!toggleDropdown)}
-                    >
-                        <div className={styles.userGreetMsg}>
-                            Hello, {userData?.first_name}
+                            {toggleDropdown && <Dropdown />}
                         </div>
-                        <Image
-                            className={styles.userProfilePic}
-                            src={
-                                userData?.picture?.url
-                                    ? `${userData?.picture?.url}`
-                                    : `${DEFAULT_AVATAR}`
-                            }
-                            alt="Profile Pic"
-                            width="32"
-                            height="32"
-                        />
-                        {toggleDropdown && <Dropdown />}
-                    </div>
+                    ) : (
+                        <Link href={LOGIN_URL}>
+                            <button className={styles.signInLink}>
+                                Sign In With Github
+                                <Image
+                                    className={styles.githubLogo}
+                                    src={GITHUB_LOGO}
+                                    height="20"
+                                    width="20"
+                                    alt="GitHub Icon"
+                                />
+                            </button>
+                        </Link>
+                    )
+                ) : (
+                    ''
                 )}
             </div>
         </nav>

--- a/src/components/navBar/index.tsx
+++ b/src/components/navBar/index.tsx
@@ -78,8 +78,8 @@ const NavBar = () => {
                 </ul>
             </div>
             <div className={styles.userProfile}>
-                {userData !== undefined ? (
-                    userData ? (
+                {userData !== undefined &&
+                    (userData ? (
                         <div
                             className={styles.userGreet}
                             onClick={() => setToggleDropdown(!toggleDropdown)}
@@ -113,10 +113,7 @@ const NavBar = () => {
                                 />
                             </button>
                         </Link>
-                    )
-                ) : (
-                    ''
-                )}
+                    ))}
             </div>
         </nav>
     );

--- a/src/components/navBar/index.tsx
+++ b/src/components/navBar/index.tsx
@@ -78,7 +78,7 @@ const NavBar = () => {
                 </ul>
             </div>
             <div className={styles.userProfile}>
-                {userData !== undefined &&
+                {!!userData &&
                     (userData ? (
                         <div
                             className={styles.userGreet}


### PR DESCRIPTION
### Issue:
https://github.com/Real-Dev-Squad/website-status/issues/746
### Description:
`Login with Github` button showing have been handled in the Navbar while refreshing the Pages, when user already Loggedin
### Anthing you would like to inform the reviewer about:

### Dev Tested:
- [x] Yes


### Images/video of the change:
**Before:**


https://github.com/Real-Dev-Squad/website-status/assets/69259490/24548937-15bb-466a-86ff-aaf1cc0395fc

**After:**


https://github.com/Real-Dev-Squad/website-status/assets/69259490/1a95ab8b-fc42-4bca-8226-039bb9d3f4cf

### Test Coverage Stats:

![image](https://github.com/Real-Dev-Squad/website-status/assets/69259490/db07f59c-e4a5-45a5-80fc-c265ced528ca)


### Follow-up Issues (if any)
