### PR TITLE
fix idle users card to redirect to user management page

### DIFF
--- a/__tests__/Unit/Components/IdleUsers/Card.test.tsx
+++ b/__tests__/Unit/Components/IdleUsers/Card.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import Card from '@/components/idleUsers/card';
 import getIdleSinceText from '@/helperFunctions/getIdleSinceText';
-import { MEMBERS_URL } from '@/constants/url';
+import { USER_MANAGEMENT_URL } from '@/constants/url';
 const user = {
     id: 'H3vNvHtFfp1Y57tPNoQ1',
     currentStatus: {
@@ -19,7 +19,7 @@ const user = {
 };
 
 describe('Idle User Card', () => {
-    const profileUrl = `${MEMBERS_URL}/${user.username}`;
+    const profileUrl = `${USER_MANAGEMENT_URL}/?username=${user.username}`;
 
     it('should render card', () => {
         render(<Card user={user} />);

--- a/src/components/idleUsers/card/index.tsx
+++ b/src/components/idleUsers/card/index.tsx
@@ -5,7 +5,7 @@ import { UserStatus } from '@/interfaces/userStatus.type';
 import getIdleSinceText from '@/helperFunctions/getIdleSinceText';
 import styles from '@/components/idleUsers/card/card.module.scss';
 import { DUMMY_PROFILE } from '@/constants/display-sections.js';
-import { MEMBERS_URL } from '@/constants/url';
+import { USER_MANAGEMENT_URL } from '@/constants/url';
 
 type Props = {
     user: UserStatus;
@@ -14,7 +14,7 @@ type Props = {
 const Card: FC<Props> = ({ user }) => {
     const userImg = user?.picture?.url;
     const idleSinceText = getIdleSinceText(user.currentStatus.from);
-    const profileUrl = `${MEMBERS_URL}/${user.username}`;
+    const profileUrl = `${USER_MANAGEMENT_URL}/?username=${user.username}`;
 
     return (
         <Link

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -26,3 +26,5 @@ export const ITEM_TYPES = { task: 'TASK' };
 export const TASKS_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/tasks`;
 export const ISSUES_URL = `${process.env.NEXT_PUBLIC_BASE_URL}/issues`;
 export const USERS_URL = `${BASE_URL}/users`;
+export const USER_MANAGEMENT_URL =
+    'https://dashboard.realdevsquad.com/users/details/';


### PR DESCRIPTION
## Pull Request Description

**Issue Reference:** #740 

**Description:**
This pull request addresses issue #740 , where the "Idle Users" card in the status site's idle users dashboard redirects users to the "Members" page, causing confusion for external users since not all idle users are members of the organization. This pull request proposes a solution to redirect the "Idle Users" card to the "User Management" page instead, offering a more comprehensive view of all idle users, including both members and non-members.

**Proposed Changes:**
1. Modify the "Idle Users" card click behavior to redirect to the "User Management" page.
2. Update the necessary links and routes to ensure seamless redirection.

**Reasoning:**
Redirecting to the "User Management" page improves the user experience for external users by providing a centralized location to manage idle users effectively. This avoids the inconvenience of encountering 404 errors for non-member users and allows administrators to access crucial user details.

**Expected Behavior:**
After merging this pull request, when a user clicks on the "Idle Users" card, they will be directed to the "User Management" page.

**Testing:**
1. Verify that clicking the "Idle Users" card redirects to the "User Management" page.

**Additional Notes:**
- Review the layout and functionality of the "User Management" page to accommodate the integration of idle user details seamlessly.
- Consider any potential performance impacts and evaluate the impact on existing workflows of organization administrators during testing.

**Related Issues:**
- #740  
Please review and approve this pull request for merging. Thank you!
