### PR TITLE
760 add dropdown for task status mobile

### DIFF
--- a/__tests__/Unit/Components/Select/Select.test.tsx
+++ b/__tests__/Unit/Components/Select/Select.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect'; // For additional DOM matchers
+import { Select } from '@/components/Select';
+
+const sampleOptions = [
+    { label: 'Option 1', value: 'option1' },
+    { label: 'Option 2', value: 'option2' },
+    { label: 'Option 3', value: 'option3' },
+];
+
+const onSelectMock = jest.fn();
+describe('Select', () => {
+    test('renders with initial state', () => {
+        const value = sampleOptions[0];
+        render(
+            <Select
+                value={value}
+                onChange={() => onSelectMock()}
+                options={sampleOptions}
+            />
+        );
+
+        expect(screen?.queryByTestId('selected-option')).toBeInTheDocument();
+
+        expect(screen?.queryByTestId('options')).not.toHaveClass('show');
+    });
+
+    test('opens dropdown when clicked', () => {
+        const value = sampleOptions[0];
+        render(
+            <Select
+                value={value}
+                onChange={() => onSelectMock()}
+                options={sampleOptions}
+            />
+        );
+        const selectContainer = screen?.getByRole('button', {
+            name: value.label,
+        });
+
+        fireEvent.click(selectContainer);
+
+        expect(screen?.getByTestId('options')).toBeVisible();
+    });
+
+    test('selects an option', () => {
+        const value = sampleOptions[0];
+        const onChangeMock = jest.fn();
+        render(
+            <Select
+                value={value}
+                onChange={onChangeMock}
+                options={sampleOptions}
+            />
+        );
+
+        const option2 = screen?.getByText('Option 2');
+        fireEvent.click(option2);
+
+        expect(onChangeMock).toHaveBeenCalledWith(sampleOptions[1]);
+    });
+});

--- a/__tests__/Unit/Components/Select/Select.test.tsx
+++ b/__tests__/Unit/Components/Select/Select.test.tsx
@@ -19,7 +19,7 @@ describe('Select', () => {
             />
         );
 
-        expect(screen?.queryByTestId('selected-option')).toBeInTheDocument();
+        expect(screen.queryByTestId('selected-option')).toBeInTheDocument();
 
         expect(screen?.queryByTestId('options')).not.toHaveClass('show');
     });

--- a/__tests__/Unit/Components/Select/Select.test.tsx
+++ b/__tests__/Unit/Components/Select/Select.test.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect'; // For additional DOM matchers
 import { Select } from '@/components/Select';
 
 const sampleOptions = [

--- a/__tests__/Unit/Components/Select/Select.test.tsx
+++ b/__tests__/Unit/Components/Select/Select.test.tsx
@@ -41,7 +41,7 @@ describe('Select', () => {
 
         fireEvent.click(selectContainer);
 
-        expect(screen?.getByTestId('options')).toBeVisible();
+        expect(screen?.queryByTestId('options')).toHaveClass('show');
     });
 
     test('selects an option', () => {
@@ -59,5 +59,123 @@ describe('Select', () => {
         fireEvent.click(option2);
 
         expect(onChangeMock).toHaveBeenCalledWith(sampleOptions[1]);
+    });
+
+    test('handler should not be called when event target is not a child of container', () => {
+        const value = sampleOptions[0];
+        const onChangeMock = jest.fn();
+        render(
+            <Select
+                value={value}
+                onChange={onChangeMock}
+                options={sampleOptions}
+            />
+        );
+        const selectContainer = screen.getByTestId('selected-option');
+
+        // Simulate a keyboard event with a target that is not a child of the container
+        fireEvent.keyDown(document.body, { key: 'Enter' });
+
+        // The handler function should not be called since the target is not a child of the container
+        expect(onChangeMock).not.toHaveBeenCalled();
+
+        // Handler should be called when the target is a child of the container
+        fireEvent.click(selectContainer);
+        // The dropdown should be visible after the key press.
+        expect(screen?.queryByTestId('options')).toHaveClass('show');
+    });
+
+    test('navigates options with arrow keys', () => {
+        const value = sampleOptions[0];
+        const onChangeMock = jest.fn();
+        render(
+            <Select
+                value={value}
+                onChange={onChangeMock}
+                options={sampleOptions}
+            />
+        );
+        const selectContainer = screen.getByRole('button');
+        // Simulate pressing the "ArrowDown" key to open the dropdown.
+        fireEvent.keyDown(selectContainer, {
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+        });
+        // The dropdown should be visible after the key press.
+        expect(screen.getByTestId('options')).toBeVisible();
+
+        // Simulate pressing the "ArrowDown" key to open the dropdown.
+        fireEvent.keyDown(selectContainer, {
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+        });
+
+        // The second option should be highlighted.
+        expect(screen.getByText('Option 2')).toHaveClass('highlighted');
+    });
+
+    test('using escape key for closing the options', () => {
+        const value = sampleOptions[0];
+        const onChangeMock = jest.fn();
+        render(
+            <Select
+                value={value}
+                onChange={onChangeMock}
+                options={sampleOptions}
+            />
+        );
+        const selectContainer = screen.getByRole('button'); // Change this to use the new data-testid
+        fireEvent.click(selectContainer);
+        // The dropdown should be visible after the key press.
+        expect(screen.getByTestId('options')).toBeVisible();
+
+        // Simulate pressing the "Escape" key to close the dropdown.
+        fireEvent.keyDown(selectContainer, { key: 'Escape', code: 'Escape' });
+
+        //  The dropdown should be closed after selecting an option.
+        expect(screen?.queryByTestId('options')).not.toHaveClass('show');
+    });
+
+    test('handler should close the dropdown when the container loses focus (onBlur event)', () => {
+        const value = sampleOptions[0];
+        const onChangeMock = jest.fn();
+        render(
+            <Select
+                value={value}
+                onChange={onChangeMock}
+                options={sampleOptions}
+            />
+        );
+        const selectContainer = screen.getByTestId('selected-option');
+        const optionsList = screen.getByTestId('options');
+
+        // Open the dropdown by simulating a click on the select container
+        fireEvent.click(selectContainer);
+        expect(optionsList).toBeVisible();
+
+        // Simulate blur event on the select container
+        fireEvent.blur(selectContainer);
+
+        // The dropdown should be closed after the container loses focus
+        expect(screen?.queryByTestId('options')).not.toHaveClass('show');
+    });
+
+    test('handler should set the highlighted index when an option is hovered (onMouseEnter event)', () => {
+        const value = sampleOptions[0];
+        const onChangeMock = jest.fn();
+        render(
+            <Select
+                value={value}
+                onChange={onChangeMock}
+                options={sampleOptions}
+            />
+        );
+        const optionElement = screen.getByText('Option 2');
+
+        // Simulate mouse enter on the option element
+        fireEvent.mouseEnter(optionElement);
+
+        // The highlighted index should be set to the index of the hovered option
+        expect(optionElement).toHaveClass('highlighted');
     });
 });

--- a/__tests__/Unit/Components/Select/Select.test.tsx
+++ b/__tests__/Unit/Components/Select/Select.test.tsx
@@ -124,8 +124,9 @@ describe('Select', () => {
                 options={sampleOptions}
             />
         );
-        const selectContainer = screen.getByRole('button'); // Change this to use the new data-testid
+        const selectContainer = screen.getByRole('button');
         fireEvent.click(selectContainer);
+
         // The dropdown should be visible after the key press.
         expect(screen.getByTestId('options')).toBeVisible();
 

--- a/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
@@ -7,6 +7,8 @@ import { Provider } from 'react-redux';
 import { store } from '@/app/store';
 import { NO_TASKS_FOUND_MESSAGE } from '@/constants/messages';
 import { noTasksFoundHandler } from '../../../../__mocks__//handlers/tasks.handler';
+import { TABS } from '@/interfaces/task.type';
+import { getChangedStatusName } from '@/utils/getChangedStatusName';
 
 const server = setupServer(...handlers);
 
@@ -256,7 +258,7 @@ describe('tasks content', () => {
         expect(mockPushFunction).toBeCalledTimes(1);
         expect(mockPushFunction).toBeCalledWith({
             query: {
-                section: 'assigned',
+                section: TABS[1].toLowerCase(),
             },
         });
     });

--- a/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
@@ -1,7 +1,7 @@
 import { TasksContent } from '@/components/tasks/TasksContent';
 import { setupServer } from 'msw/node';
 import handlers from '../../../../__mocks__/handlers';
-import { act, fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, within } from '@testing-library/react';
 import { renderWithRouter } from '@/test_utils/createMockRouter';
 import { Provider } from 'react-redux';
 import { store } from '@/app/store';
@@ -17,7 +17,20 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('tasks content', () => {
+    const breakpointToShowSelect = 440;
+    const breakpointToShowTabs = breakpointToShowSelect + 450;
+
+    const setWindowInnerWidth = (width: number) => {
+        // Change the viewport to 500px.
+        global.innerWidth = width;
+
+        // Trigger the window resize event.
+        global.dispatchEvent(new Event('resize'));
+    };
+
     test('renders tabs component', async () => {
+        setWindowInnerWidth(breakpointToShowTabs);
+
         renderWithRouter(
             <Provider store={store()}>
                 <TasksContent dev={false} />
@@ -25,10 +38,12 @@ describe('tasks content', () => {
         );
 
         expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
         await screen.findByTestId('tabs');
     });
 
     test('select tab and set active', async () => {
+        setWindowInnerWidth(breakpointToShowTabs);
         renderWithRouter(
             <Provider store={store()}>
                 <TasksContent dev={false} />
@@ -38,7 +53,10 @@ describe('tasks content', () => {
             }
         );
         await screen.findByTestId('tabs');
-        const assignedButton = screen.getByRole('button', {
+        const tabsContainer = within(
+            screen.getByTestId('status-tabs-container')
+        );
+        const assignedButton = tabsContainer.getByRole('button', {
             name: /assigned/i,
         });
         expect(assignedButton).toHaveClass('active');
@@ -65,6 +83,7 @@ describe('tasks content', () => {
             { query: { dev: 'true', section: 'available' } }
         );
         await screen.findByTestId('tabs');
+
         const task = await findByText(
             'Design and develop an online booking system'
         );
@@ -79,7 +98,10 @@ describe('tasks content', () => {
             { query: { dev: 'false', section: 'available' } }
         );
         await screen.findByTestId('tabs');
-        const unassignedButton = screen.getByRole('button', {
+        const tabsContainer = within(
+            screen.getByTestId('status-tabs-container')
+        );
+        const unassignedButton = tabsContainer.getByRole('button', {
             name: /UNASSINGED/i,
         });
         expect(unassignedButton).toHaveClass('active');
@@ -98,6 +120,7 @@ describe('tasks content', () => {
             { query: { dev: 'true' } }
         );
         await screen.findByTestId('tabs');
+
         const loadMoreButton = screen.getByRole('button', {
             name: /load more/i,
         });
@@ -112,6 +135,7 @@ describe('tasks content', () => {
             { query: { dev: 'true' } }
         );
         await screen.findByTestId('tabs');
+
         const loadMoreButton = screen.getByRole('button', {
             name: /load more/i,
         });
@@ -141,17 +165,8 @@ describe('tasks content', () => {
         expect(task2).toBeInTheDocument();
     });
 
-    const breakpointToShowSelect = 440;
-    const breakpointToShowTabs = breakpointToShowSelect + 450;
-
-    const setWindowInnerWidth = (width: number) => {
-        act(() => {
-            window.innerWidth = width;
-            window.dispatchEvent(new Event('resize'));
-        });
-    };
-
     test('Selecting a tab pushes into query params', async () => {
+        setWindowInnerWidth(breakpointToShowTabs);
         const mockPushFunction = jest.fn();
         renderWithRouter(
             <Provider store={store()}>
@@ -159,13 +174,16 @@ describe('tasks content', () => {
             </Provider>,
             { push: mockPushFunction }
         );
-        setWindowInnerWidth(breakpointToShowTabs);
+
         await screen.findByTestId('tabs');
-        const inProgressBtn = screen.getByRole('button', {
+        const tabsContainer = within(
+            screen.getByTestId('status-tabs-container')
+        );
+        const inProgressBtn = tabsContainer.getByRole('button', {
             name: /IN PROGRESS/i,
         });
         expect(inProgressBtn).toHaveClass('active');
-        const unassignedButton = screen.getByRole('button', {
+        const unassignedButton = tabsContainer.getByRole('button', {
             name: /UNASSINGED/i,
         });
         fireEvent.click(unassignedButton);
@@ -177,7 +195,8 @@ describe('tasks content', () => {
         });
     });
 
-    test('should show status-tabs-container after 450px of screen width', () => {
+    test('should show status-tabs-container after 450px of screen width', async () => {
+        setWindowInnerWidth(breakpointToShowTabs);
         const mockPushFunction = jest.fn();
         renderWithRouter(
             <Provider store={store()}>
@@ -185,13 +204,15 @@ describe('tasks content', () => {
             </Provider>,
             { push: mockPushFunction }
         );
-        setWindowInnerWidth(breakpointToShowTabs);
+
+        await screen.findByTestId('tabs');
         const tabsContainer = screen.getByTestId('status-tabs-container');
         const tabStyles = getComputedStyle(tabsContainer);
         expect(tabStyles.display).toBe('block');
     });
 
-    test('should show status-select-container 450px below status-tabs-container', () => {
+    test('should show status-select-container 450px below status-tabs-container', async () => {
+        setWindowInnerWidth(breakpointToShowSelect);
         const mockPushFunction = jest.fn();
         renderWithRouter(
             <Provider store={store()}>
@@ -199,7 +220,7 @@ describe('tasks content', () => {
             </Provider>,
             { push: mockPushFunction }
         );
-        setWindowInnerWidth(breakpointToShowSelect);
+        await screen.findByTestId('status-select-container');
         const selectContainer = screen.getByTestId('status-select-container');
         const selectStyles = getComputedStyle(selectContainer);
 
@@ -207,6 +228,7 @@ describe('tasks content', () => {
     });
 
     test('Selecting a value from dropdown pushes into query params', async () => {
+        setWindowInnerWidth(breakpointToShowSelect);
         const mockPushFunction = jest.fn();
         renderWithRouter(
             <Provider store={store()}>
@@ -215,6 +237,7 @@ describe('tasks content', () => {
             { push: mockPushFunction }
         );
 
+        await screen.findByTestId('status-select-container');
         const selectContainer = screen?.getByTestId(
             'selected-option-container'
         );

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -14,13 +14,13 @@ export function Select({ value, onChange, options }: SelectProps) {
     // Accessiblity
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {
-            if (e.target != containerRef.current) return;
+            if (
+                e.target != containerRef.current &&
+                !containerRef?.current?.contains(e.target as Node)
+            )
+                return;
+
             switch (e.code) {
-                case 'Enter':
-                case 'Space':
-                    setIsOpen((prev) => !prev);
-                    if (isOpen) selectOption(options[highlightedIndex]);
-                    break;
                 case 'ArrowUp':
                 case 'ArrowDown': {
                     if (!isOpen) {
@@ -51,7 +51,9 @@ export function Select({ value, onChange, options }: SelectProps) {
         <div
             ref={containerRef}
             onBlur={() => setIsOpen(false)}
-            onClick={() => setIsOpen((prev) => !prev)}
+            onClick={() => {
+                setIsOpen((prev) => !prev);
+            }}
             tabIndex={0}
             className={styles.container}
         >

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -11,9 +11,9 @@ export function Select({ value, onChange, options }: SelectProps) {
         if (option !== value) onChange(option);
     }
 
-    function isOptionSelected(option: SelectOption) {
-        return option === value;
-    }
+    // function isOptionSelected(option: SelectOption) {
+    //     return option === value;
+    // }
 
     // Accessiblity
     useEffect(() => {
@@ -54,14 +54,21 @@ export function Select({ value, onChange, options }: SelectProps) {
     return (
         <div
             ref={containerRef}
-            onBlur={() => setIsOpen(false)}
+            // onBlur={() => setIsOpen(false)}
             onClick={() => setIsOpen((prev) => !prev)}
             tabIndex={0}
             className={styles.container}
         >
-            <span className={styles.value}>{value?.label}</span>
-            <div className={styles.caret}></div>
-            <ul className={`${styles.options} ${isOpen ? styles.show : ''}`}>
+            <button className={styles['selected-option-container']}>
+                <span className={styles.value} data-testid="selected-option">
+                    {value?.label}
+                </span>
+                <div className={styles.caret}></div>
+            </button>
+            <ul
+                className={`${styles.options} ${isOpen ? styles.show : ''}`}
+                data-testid="options"
+            >
                 {options.map((option, index) => (
                     <li
                         onClick={(e) => {
@@ -71,11 +78,9 @@ export function Select({ value, onChange, options }: SelectProps) {
                         }}
                         onMouseEnter={() => setHighlightedIndex(index)}
                         key={option.value}
-                        className={`${styles.option} ${
-                            isOptionSelected(option) ? styles.selected : ''
-                        } ${
+                        className={`${
                             index === highlightedIndex ? styles.highlighted : ''
-                        }`}
+                        } ${styles.option}`}
                     >
                         {option.label}
                     </li>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -23,7 +23,10 @@ export function Select({ value, onChange, options }: SelectProps) {
             switch (e.code) {
                 case 'Enter':
                 case 'Space':
-                    if (isOpen) selectOption(options[highlightedIndex]);
+                    if (isOpen) {
+                        selectOption(options[highlightedIndex]);
+                        setIsOpen(false);
+                    }
                     break;
                 case 'ArrowUp':
                 case 'ArrowDown': {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -14,6 +14,7 @@ export function Select({ value, onChange, options }: SelectProps) {
     // Accessiblity
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {
+            e.preventDefault();
             if (
                 e.target != containerRef.current &&
                 !containerRef?.current?.contains(e.target as Node)

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -21,6 +21,10 @@ export function Select({ value, onChange, options }: SelectProps) {
                 return;
 
             switch (e.code) {
+                case 'Enter':
+                case 'Space':
+                    if (isOpen) selectOption(options[highlightedIndex]);
+                    break;
                 case 'ArrowUp':
                 case 'ArrowDown': {
                     if (!isOpen) {
@@ -57,7 +61,10 @@ export function Select({ value, onChange, options }: SelectProps) {
             tabIndex={0}
             className={styles.container}
         >
-            <button className={styles['selected-option-container']}>
+            <button
+                className={styles['selected-option-container']}
+                data-testid="selected-option-container"
+            >
                 <span className={styles.value} data-testid="selected-option">
                     {value?.label}
                 </span>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -11,10 +11,6 @@ export function Select({ value, onChange, options }: SelectProps) {
         if (option !== value) onChange(option);
     }
 
-    // function isOptionSelected(option: SelectOption) {
-    //     return option === value;
-    // }
-
     // Accessiblity
     useEffect(() => {
         const handler = (e: KeyboardEvent) => {
@@ -54,7 +50,7 @@ export function Select({ value, onChange, options }: SelectProps) {
     return (
         <div
             ref={containerRef}
-            // onBlur={() => setIsOpen(false)}
+            onBlur={() => setIsOpen(false)}
             onClick={() => setIsOpen((prev) => !prev)}
             tabIndex={0}
             className={styles.container}

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from 'react';
+import styles from './select.module.scss';
+import { SelectOption, SelectProps } from '@/types/Select';
+
+export function Select({ value, onChange, options }: SelectProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [highlightedIndex, setHighlightedIndex] = useState(0);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    function selectOption(option: SelectOption) {
+        if (option !== value) onChange(option);
+    }
+
+    function isOptionSelected(option: SelectOption) {
+        return option === value;
+    }
+
+    // Accessiblity
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.target != containerRef.current) return;
+            switch (e.code) {
+                case 'Enter':
+                case 'Space':
+                    setIsOpen((prev) => !prev);
+                    if (isOpen) selectOption(options[highlightedIndex]);
+                    break;
+                case 'ArrowUp':
+                case 'ArrowDown': {
+                    if (!isOpen) {
+                        setIsOpen(true);
+                        break;
+                    }
+
+                    const newValue =
+                        highlightedIndex + (e.code === 'ArrowDown' ? 1 : -1);
+                    if (newValue >= 0 && newValue < options.length) {
+                        setHighlightedIndex(newValue);
+                    }
+                    break;
+                }
+                case 'Escape':
+                    setIsOpen(false);
+                    break;
+            }
+        };
+        containerRef.current?.addEventListener('keydown', handler);
+
+        return () => {
+            containerRef.current?.removeEventListener('keydown', handler);
+        };
+    }, [isOpen, highlightedIndex, options]);
+
+    return (
+        <div
+            ref={containerRef}
+            onBlur={() => setIsOpen(false)}
+            onClick={() => setIsOpen((prev) => !prev)}
+            tabIndex={0}
+            className={styles.container}
+        >
+            <span className={styles.value}>{value?.label}</span>
+            <div className={styles.caret}></div>
+            <ul className={`${styles.options} ${isOpen ? styles.show : ''}`}>
+                {options.map((option, index) => (
+                    <li
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            selectOption(option);
+                            setIsOpen(false);
+                        }}
+                        onMouseEnter={() => setHighlightedIndex(index)}
+                        key={option.value}
+                        className={`${styles.option} ${
+                            isOptionSelected(option) ? styles.selected : ''
+                        } ${
+                            index === highlightedIndex ? styles.highlighted : ''
+                        }`}
+                    >
+                        {option.label}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -1,0 +1,71 @@
+$theme-grey: #d4d4d5;
+$theme-grey-light: #f1f1f5;
+$gray-shade-color: #808080;
+$gray-shade-color2: #5c5b5b;
+$black: #000;
+$border-color: #d4d4d5;
+.container {
+    position: relative;
+    width: 20em;
+    min-height: 1.5em;
+    border: 2px solid $border-color;
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: 0.5em;
+    border-radius: 0.25em;
+    outline: none;
+    margin: auto;
+}
+
+.container:focus {
+    border-color: $gray-shade-color2;
+}
+
+.value {
+    flex-grow: 1;
+    display: flex;
+    gap: 0.5em;
+    flex-wrap: wrap;
+    font-weight: bold;
+}
+
+.caret {
+    translate: 0 25%;
+    border: 0.25em solid transparent;
+    border-top-color: $gray-shade-color2;
+}
+
+.options {
+    position: absolute;
+    margin: 0;
+    padding: 0rem;
+    list-style: none;
+    display: none;
+    max-height: 15em;
+    overflow-y: auto;
+    border: 0.05em solid $gray-shade-color2;
+    border-radius: 0.25em;
+    width: 100%;
+    left: 0;
+    top: calc(100% + 0.25em);
+    background-color: white;
+    z-index: 100;
+}
+
+.options.show {
+    display: block;
+}
+
+.option {
+    padding: 0.5em 0.5em;
+    cursor: pointer;
+}
+
+.option.selected {
+    background-color: $gray-shade-color2;
+}
+
+.option.highlighted {
+    background-color: $theme-grey-light;
+}

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -22,6 +22,19 @@ $border-color: #d4d4d5;
     border-color: $gray-shade-color2;
 }
 
+.selected-option-container {
+    background: none;
+    color: inherit;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    outline: inherit;
+    display: flex;
+    width: 100%;
+    align-items: center;
+}
+
 .value {
     flex-grow: 1;
     display: flex;
@@ -34,6 +47,8 @@ $border-color: #d4d4d5;
     translate: 0 25%;
     border: 0.25em solid transparent;
     border-top-color: $gray-shade-color2;
+    width: 8px;
+    height: 8px;
 }
 
 .options {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -7,7 +7,7 @@ type TabsProps = {
     onSelect: (tab: Tab) => void;
     activeTab: Tab;
 };
-function changeName(name: string) {
+export function changeName(name: string) {
     if (name === COMPLETED) {
         return DONE;
     } else if (name === AVAILABLE) {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,21 +1,12 @@
 import styles from '@/components/Tabs/Tabs.module.scss';
 import { Tab } from '@/interfaces/task.type';
-import { COMPLETED, DONE, AVAILABLE, UNASSINGED } from '@/constants/constants';
+import { getChangedStatusName } from '@/utils/getChangedStatusName';
 
 type TabsProps = {
     tabs: Tab[];
     onSelect: (tab: Tab) => void;
     activeTab: Tab;
 };
-export function changeName(name: string) {
-    if (name === COMPLETED) {
-        return DONE;
-    } else if (name === AVAILABLE) {
-        return UNASSINGED;
-    } else {
-        return name.split('_').join(' ');
-    }
-}
 
 const Tabs = ({ tabs, onSelect, activeTab }: TabsProps) => (
     <>
@@ -27,7 +18,7 @@ const Tabs = ({ tabs, onSelect, activeTab }: TabsProps) => (
                     activeTab === tab ? styles.active : ''
                 }`}
             >
-                {changeName(tab)}
+                {getChangedStatusName(tab)}
             </button>
         ))}
     </>

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -10,7 +10,7 @@ import { TabSection } from './TabSection';
 import TaskList from './TaskList/TaskList';
 import { useRouter } from 'next/router';
 import { getActiveTab } from '@/utils/getActiveTab';
-import Tabs, { changeName } from '../Tabs';
+import { changeName } from '../Tabs';
 import { Select } from '../Select';
 
 type RenderTaskListProps = {
@@ -108,9 +108,9 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
         }
     }, [tasksData.tasks]);
 
-    // if (isLoading) return <p>Loading...</p>;
+    if (isLoading) return <p>Loading...</p>;
 
-    // if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
+    if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
     const taskSelectOptions = TABS.map((item) => ({
         label: changeName(item),
         value: item,

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -10,8 +10,9 @@ import { TabSection } from './TabSection';
 import TaskList from './TaskList/TaskList';
 import { useRouter } from 'next/router';
 import { getActiveTab } from '@/utils/getActiveTab';
-import { changeName } from '../Tabs';
+
 import { Select } from '../Select';
+import { getChangedStatusName } from '@/utils/getChangedStatusName';
 
 type RenderTaskListProps = {
     tab: string;
@@ -108,29 +109,34 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
         }
     }, [tasksData.tasks]);
 
-    if (isLoading) return <p>Loading...</p>;
+    // if (isLoading) return <p>Loading...</p>;
 
-    if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
+    // if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
     const taskSelectOptions = TABS.map((item) => ({
-        label: changeName(item),
+        label: getChangedStatusName(item),
         value: item,
     }));
 
     return (
         <div className={classNames.tasksContainer}>
-            <div className={classNames['status-tabs-container']}>
+            <div
+                className={classNames['status-tabs-container']}
+                data-testid="status-tabs-container"
+            >
                 <TabSection onSelect={onSelect} activeTab={selectedTab} />
             </div>
-            <div className={classNames['status-select-container']}>
+            <div
+                className={classNames['status-select-container']}
+                data-testid="status-select-container"
+            >
                 <Select
                     value={{
-                        label: changeName(selectedTab),
+                        label: getChangedStatusName(selectedTab),
                         value: selectedTab,
                     }}
-                    onChange={(o) => {
-                        if (o) {
-                            console.log(o);
-                            onSelect(o.value as Tab);
+                    onChange={(selectedTaskStatus) => {
+                        if (selectedTaskStatus) {
+                            onSelect(selectedTaskStatus.value as Tab);
                         }
                     }}
                     options={taskSelectOptions}

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -1,6 +1,6 @@
 import classNames from '@/styles/tasks.module.scss';
 import { useGetAllTasksQuery } from '@/app/services/tasksApi';
-import task, { Tab, TabTasksData } from '@/interfaces/task.type';
+import task, { TABS, Tab, TabTasksData } from '@/interfaces/task.type';
 import { useState, useEffect } from 'react';
 import {
     NO_TASKS_FOUND_MESSAGE,
@@ -10,6 +10,8 @@ import { TabSection } from './TabSection';
 import TaskList from './TaskList/TaskList';
 import { useRouter } from 'next/router';
 import { getActiveTab } from '@/utils/getActiveTab';
+import Tabs, { changeName } from '../Tabs';
+import { Select } from '../Select';
 
 type RenderTaskListProps = {
     tab: string;
@@ -48,6 +50,7 @@ type routerQueryParams = {
     section?: string;
 };
 export const TasksContent = ({ dev }: { dev: boolean }) => {
+    console.log('tabs', TABS);
     const router = useRouter();
     const { section }: routerQueryParams = router.query;
     const selectedTab = getActiveTab(section);
@@ -106,13 +109,34 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
         }
     }, [tasksData.tasks]);
 
-    if (isLoading) return <p>Loading...</p>;
+    // if (isLoading) return <p>Loading...</p>;
 
-    if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
+    // if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
+    const taskSelectOptions = TABS.map((item) => ({
+        label: changeName(item),
+        value: item,
+    }));
 
     return (
         <div className={classNames.tasksContainer}>
-            <TabSection onSelect={onSelect} activeTab={selectedTab} />
+            <div className={classNames['status-tabs-container']}>
+                <TabSection onSelect={onSelect} activeTab={selectedTab} />
+            </div>
+            <div className={classNames['status-select-container']}>
+                <Select
+                    value={{
+                        label: changeName(selectedTab),
+                        value: selectedTab,
+                    }}
+                    onChange={(o) => {
+                        if (o) {
+                            console.log(o);
+                            onSelect(o.value as Tab);
+                        }
+                    }}
+                    options={taskSelectOptions}
+                />
+            </div>
             <div>
                 <RenderTaskList
                     dev={dev}
@@ -120,7 +144,6 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
                     tasks={loadedTasks[selectedTab]}
                 />
             </div>
-
             {dev && (
                 <button
                     className={classNames.loadMoreButton}

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -109,9 +109,9 @@ export const TasksContent = ({ dev }: { dev: boolean }) => {
         }
     }, [tasksData.tasks]);
 
-    // if (isLoading) return <p>Loading...</p>;
+    if (isLoading) return <p>Loading...</p>;
 
-    // if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
+    if (isError) return <p>{TASKS_FETCH_ERROR_MESSAGE}</p>;
     const taskSelectOptions = TABS.map((item) => ({
         label: getChangedStatusName(item),
         value: item,

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -50,7 +50,6 @@ type routerQueryParams = {
     section?: string;
 };
 export const TasksContent = ({ dev }: { dev: boolean }) => {
-    console.log('tabs', TABS);
     const router = useRouter();
     const { section }: routerQueryParams = router.query;
     const selectedTab = getActiveTab(section);

--- a/src/styles/tasks.module.scss
+++ b/src/styles/tasks.module.scss
@@ -37,6 +37,21 @@ $disabledColor: gray;
     flex-wrap: wrap;
 }
 
+.status-tabs-container {
+    display: block;
+    @media (max-width: 450px) {
+        display: none;
+    }
+}
+
+.status-select-container {
+    display: none;
+    padding: 1rem;
+    @media (max-width: 450px) {
+        display: block;
+    }
+}
+
 .loadMoreButton {
     border: none;
     border-radius: 0.5rem;

--- a/src/types/Select.d.ts
+++ b/src/types/Select.d.ts
@@ -1,0 +1,13 @@
+export type SelectOption = {
+    label: string;
+    value: string | number;
+};
+
+export type SingleSelectProps = {
+    value?: SelectOption;
+    onChange: (value: SelectOption | undefined) => void;
+};
+
+export type SelectProps = {
+    options: SelectOption[];
+} & SingleSelectProps;

--- a/src/utils/getChangedStatusName.ts
+++ b/src/utils/getChangedStatusName.ts
@@ -1,0 +1,10 @@
+import { COMPLETED, DONE, AVAILABLE, UNASSINGED } from '@/constants/constants';
+export function getChangedStatusName(name: string) {
+    if (name === COMPLETED) {
+        return DONE;
+    } else if (name === AVAILABLE) {
+        return UNASSINGED;
+    } else {
+        return name.split('_').join(' ');
+    }
+}


### PR DESCRIPTION
### Issue:
https://github.com/Real-Dev-Squad/website-status/issues/760

### Description:
Currently the task status tabs look cluttered in mobile.Added dropdown for task status in mobile so it looks cleaner.
Created Select component for the same and added tests as well

### Dev Tested:
- Yes
Test coverage:
<img width="765" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/70846516/9bdb56d6-4aec-4467-ab00-33130eb0a2a8">

-------------------------------

<img width="765" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/70846516/8c7010dd-3968-4987-8645-95666292ef8b">






### Images/video of the change:
<img width="383" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/70846516/5cbe88d0-2989-4a43-9c20-d9212e02887d">

