### PR TITLE
Remove users status feature flag

### DIFF
--- a/__tests__/Unit/hooks/tasksApi.test.tsx
+++ b/__tests__/Unit/hooks/tasksApi.test.tsx
@@ -322,39 +322,6 @@ describe('useUpdateTaskMutation()', () => {
             message: 'Task not found',
         });
     });
-
-    test('updates a task with the isDevEnabled set to true', async () => {
-        const taskId = '1eJhUW19D556AhPEpdPr';
-        const { result, waitForNextUpdate } = renderHook(
-            () => useUpdateTaskMutation(),
-            {
-                wrapper: Wrapper,
-            }
-        );
-        const [updateTask, initialResponse] = result.current;
-        expect(initialResponse.isLoading).toBe(false);
-        expect(initialResponse.data).toBeUndefined();
-
-        act(() => {
-            const task = {
-                task: updatedTaskData,
-                id: taskId,
-                isDevEnabled: true,
-            };
-            updateTask(task);
-        });
-
-        const loadingResponse = result.current[1];
-        expect(loadingResponse.isLoading).toBe(true);
-
-        await waitForNextUpdate({ timeout: 7000 });
-
-        const nextResponse = result.current[1];
-        expect(nextResponse.data).toBeNull();
-        expect(nextResponse.isSuccess).toBe(true);
-        expect(nextResponse.isLoading).toBe(false);
-        expect(nextResponse.status).toBe(QueryStatus.fulfilled);
-    }, 7000);
 });
 
 describe('useGetMineTasksQuery()', () => {

--- a/src/app/services/tasksApi.ts
+++ b/src/app/services/tasksApi.ts
@@ -58,11 +58,8 @@ export const tasksApi = api.injectEndpoints({
             }),
         }),
         updateTask: builder.mutation<void, TaskRequestPayload>({
-            // isDevEnabled is the Feature flag for status update based on task status. This flag is temporary and will be removed once the feature becomes stable.
-            query: ({ task, id, isDevEnabled }: TaskRequestPayload) => ({
-                url: isDevEnabled
-                    ? `tasks/${id}?userStatusFlag=true`
-                    : `tasks/${id}`,
+            query: ({ task, id }: TaskRequestPayload) => ({
+                url: `tasks/${id}`,
                 method: 'PATCH',
                 body: task,
             }),

--- a/src/components/tasks/TaskList/TaskList.tsx
+++ b/src/components/tasks/TaskList/TaskList.tsx
@@ -41,13 +41,9 @@ export default function TaskList({ tasks, hasLimit = false }: TaskListProps) {
     function onSeeMoreTasksHandler() {
         setTasksLimit((prevLimit) => prevLimit + ADD_MORE_TASKS_LIMIT);
     }
-    async function onContentChangeHandler(
-        id: string,
-        cardDetails: any,
-        isDevEnabled?: boolean
-    ) {
+    async function onContentChangeHandler(id: string, cardDetails: any) {
         if (!updateCardContent) return;
-        updateCardContent({ id, task: cardDetails, isDevEnabled });
+        updateCardContent({ id, task: cardDetails });
     }
 
     return (

--- a/src/components/tasks/card/index.tsx
+++ b/src/components/tasks/card/index.tsx
@@ -88,7 +88,6 @@ const Card: FC<CardProps> = ({
 
     const router = useRouter();
     const { dev } = router.query;
-    const isDevEnabled = (dev && dev === 'true') || false;
 
     useEffect(() => {
         const isAltKeyLongPressed = keyLongPressed === ALT_KEY;
@@ -147,13 +146,9 @@ const Card: FC<CardProps> = ({
                 toChange[changedProperty] = toTimeStamp;
             }
 
-            onContentChange(
-                toChange.id,
-                {
-                    [changedProperty]: toChange[changedProperty],
-                },
-                isDevEnabled
-            );
+            onContentChange(toChange.id, {
+                [changedProperty]: toChange[changedProperty],
+            });
         }
     }
 
@@ -221,7 +216,6 @@ const Card: FC<CardProps> = ({
         const response = updateTask({
             task: data,
             id: cardDetails.id,
-            ...(isDevEnabled && { isDevEnabled: true }),
         });
         response
             .unwrap()
@@ -254,7 +248,6 @@ const Card: FC<CardProps> = ({
         const response = updateTask({
             task: data,
             id: cardDetails.id,
-            ...(isDevEnabled && { isDevEnabled: true }),
         });
 
         response

--- a/src/interfaces/task.type.ts
+++ b/src/interfaces/task.type.ts
@@ -91,17 +91,12 @@ export { TABS, Tab };
 export type TaskRequestPayload = {
     task: updateTaskDetails;
     id: string;
-    isDevEnabled?: boolean;
 };
 
 export type CardProps = {
     content: task;
     shouldEdit: boolean;
-    onContentChange?: (
-        changeId: string,
-        changeObject: object,
-        isDevEnabled?: boolean
-    ) => void;
+    onContentChange?: (changeId: string, changeObject: object) => void;
 };
 
 export default task;


### PR DESCRIPTION
### Issue:
https://github.com/Real-Dev-Squad/website-backend/issues/1224

### Description:
This pull request (PR) aims to removes the userStatus flag, which is currently in use to track user status based on task. The feature is now stable and has been in prod since more than 3 weeks and as confirmed with Ankush we can remove this feature flag.

### Anything you would like to inform the reviewer about:
No

### Dev Tested:
- [x] Yes
- [ ] No

### Testing Stats

![image](https://github.com/Real-Dev-Squad/website-status/assets/97341921/aa0b60cb-368b-4267-9b72-c0fb94b3831b)

![image](https://github.com/Real-Dev-Squad/website-status/assets/97341921/14c533d2-49d9-4de6-835f-260c13c33508)

![image](https://github.com/Real-Dev-Squad/website-status/assets/97341921/89495330-7cfd-453d-a2e1-eadceb92198d)

### Images/video of the change:
![image](https://github.com/Real-Dev-Squad/website-status/assets/97341921/d9d47098-2e5d-40f0-825c-108ca267d222)

### Follow-up Issues (if any)
None