### PR TITLE
refactor endsOn type and acccomodate task id in issue

### DIFF
--- a/src/components/tasks/card/index.tsx
+++ b/src/components/tasks/card/index.tsx
@@ -102,7 +102,7 @@ const Card: FC<CardProps> = ({
     const localStartedOn = new Date(parseInt(cardDetails.startedOn, 10) * 1000);
     const fromNowStartedOn = moment(localStartedOn).fromNow();
 
-    const localEndsOn = new Date(parseInt(cardDetails.endsOn, 10) * 1000);
+    const localEndsOn = new Date(cardDetails.endsOn * 1000);
     const fromNowEndsOn = moment(localEndsOn).fromNow();
     const statusFontColor = !statusRedList.includes(
         cardDetails.status as TASK_STATUS
@@ -447,7 +447,7 @@ const Card: FC<CardProps> = ({
                             handleProgressChange={handleProgressChange}
                             debounceSlider={debounceSlider}
                             startedOn={content.startedOn}
-                            endsOn={content.endsOn}
+                            endsOn={content.endsOn?.toString()}
                         />
                     </div>
                     {dev === 'true' && (

--- a/src/interfaces/issueItem.type.ts
+++ b/src/interfaces/issueItem.type.ts
@@ -23,4 +23,5 @@ export type IssueItem = {
     created_at: string | number | Date;
     updated_at?: string | number | Date;
     taskExists?: boolean;
+    taskId?: string;
 };

--- a/src/interfaces/task.type.ts
+++ b/src/interfaces/task.type.ts
@@ -7,7 +7,7 @@ type task = {
     featureUrl: string;
     type: string;
     links: string[];
-    endsOn: string;
+    endsOn: number;
     startedOn: string;
     status: string;
     assignee?: string;
@@ -49,6 +49,9 @@ export type ProgressSliderProps = {
 export type updateTaskDetails = Partial<Omit<task, 'startedOn'>> & {
     startedOn?: number;
     percentCompleted?: number;
+    endsOn?: number;
+    status?: string;
+    assignee?: string;
 };
 
 export type ProgressBarProps = {


### PR DESCRIPTION
fix task types to accommodate ends on field to number in task type as backend returns it as a number.

also add an optional task id field to issues in to accommodate new changes in the backend to return task id of github issue if task is created.