### PR TITLE
added responsiveness to the in-review page

### DIFF
--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -4,6 +4,7 @@
     flex-direction: column;
     display: flex;
     min-height: 100%;
+    min-width:18rem;
 }
 
 .wrapper {

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -4,7 +4,7 @@
     flex-direction: column;
     display: flex;
     min-height: 100%;
-    min-width:18rem;
+    min-width: 18rem;
 }
 
 .wrapper {

--- a/src/components/Select/select.module.scss
+++ b/src/components/Select/select.module.scss
@@ -6,7 +6,7 @@ $black: #000;
 $border-color: #d4d4d5;
 .container {
     position: relative;
-    width: 20em;
+    width: 100%;
     min-height: 1.5em;
     border: 2px solid $border-color;
     display: flex;


### PR DESCRIPTION
### Issue:  https://github.com/Real-Dev-Squad/website-status/issues/675

### Description:

The card have min width of 267px because of the content inside it, like progress bar. Also the select have with 20em changed it to 100%. Now the navbar is not detaching for screen size of iPhone 4 or less. 


### Dev Tested:
- [x] Yes


### Images/video of the change:

https://github.com/Real-Dev-Squad/website-status/assets/55151241/2684caff-98b2-4d8f-ab0e-7dc13609661d



### Follow-up Issues (if any)
