### PR TITLE
disable convert to task button for non admins/superusers

### DIFF
--- a/__tests__/Unit/Components/Issues/Card.test.tsx
+++ b/__tests__/Unit/Components/Issues/Card.test.tsx
@@ -6,6 +6,20 @@ import {
     issueResponseNullBody,
     issuesResponseSearchedWithQuery,
 } from '../../../../__mocks__/db/issues';
+import { renderWithProviders } from '@/test-utils/renderWithProvider';
+
+jest.mock('@/hooks/useUserData', () => {
+    return () => ({
+        data: {
+            roles: {
+                admin: true,
+                super_user: false,
+            },
+        },
+        isUserAuthorized: true,
+        isSuccess: true,
+    });
+});
 
 describe('Issue card', () => {
     test('Should render issue title correctly', () => {
@@ -20,7 +34,7 @@ describe('Issue card', () => {
         expect(titleElement).toBeInTheDocument();
     });
     test('Should render issue information correctly', () => {
-        const screen = render(
+        const screen = renderWithProviders(
             <Card issue={issuesResponseSearchedWithQuery[0]} />
         );
         expect(
@@ -30,7 +44,7 @@ describe('Issue card', () => {
     });
 
     test('Should render issue created by information correctly', () => {
-        const screen = render(
+        const screen = renderWithProviders(
             <Card issue={issuesResponseSearchedWithQuery[0]} />
         );
         const date = new Date(
@@ -48,7 +62,7 @@ describe('Issue card', () => {
     });
 
     test('Should render the assignee information correctly', () => {
-        const screen = render(
+        const screen = renderWithProviders(
             <Card issue={issuesResponseSearchedWithQuery[0]} />
         );
         const assignee = screen.getByText(

--- a/src/components/issues/Card.tsx
+++ b/src/components/issues/Card.tsx
@@ -6,12 +6,14 @@ import { toast, ToastTypes } from '@/helperFunctions/toast';
 import fetch from '@/helperFunctions/fetch';
 import { IssueCardProps } from '@/interfaces/issueProps.type';
 import { TASKS_URL } from '../../constants/url';
+import useUserData from '@/hooks/useUserData';
 const { SUCCESS, ERROR } = ToastTypes;
 
 const Card: FC<IssueCardProps> = ({ issue }) => {
     const date = new Date(issue.created_at).toDateString();
     const [taskExists, setTaskExists] = useState(issue.taskExists ?? false);
     const [isLoading, setIsLoading] = useState(false);
+    const { isUserAuthorized } = useUserData();
 
     const getIssueInfo = () => {
         const issueInfo: any = {
@@ -119,7 +121,7 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
             <div className={styles.actions}>
                 <button
                     className={styles.card__top__button}
-                    disabled={taskExists || isLoading}
+                    disabled={taskExists || isLoading || !isUserAuthorized}
                     onClick={handleClick}
                 >
                     Convert to task


### PR DESCRIPTION
## Pull Request Description

**Issue:** #810 

**Changes Made:**
- Updated access control settings for the "Convert to Task" functionality on the issues page.
- Modified the code logic to restrict access to the "Convert to Task" option for non-admin/super users.

**Testing Done:**
- Tested the changes using different user roles (admin, superuser, regular user) on the issues page.
- Verified that only administrators and super users can see and use the "Convert to Task" option.
- Confirmed that regular users no longer have access to the "Convert to Task" option.

**Related Issues:**
Closes #810 
