### PR TITLE
fix unnecessary api call for updating task details

### DIFF
--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -193,17 +193,18 @@ describe('TaskDetails Page', () => {
             </Provider>,
             {}
         );
-
         await waitFor(() => {
             const editButton = screen.getByRole('button', { name: 'Edit' });
             fireEvent.click(editButton);
         });
         const textareaElement = screen.getByTestId('title-textarea');
-
         fireEvent.change(textareaElement, {
             target: { name: 'title', value: 'New Title' },
         });
-
+        await waitFor(() => {
+            const saveButton = screen.getByRole('button', { name: 'Save' });
+            fireEvent.click(saveButton);
+        });
         expect(textareaElement).toHaveValue('New Title');
     });
     test('should call onCancel and reset state when clicked', async () => {
@@ -258,12 +259,14 @@ describe('TaskDetails Page', () => {
             </Provider>,
             {}
         );
-
         await waitFor(() => {
             const editButton = screen.getByRole('button', { name: 'Edit' });
             fireEvent.click(editButton);
         });
-
+        const textareaElement = screen.getByTestId('title-textarea');
+        fireEvent.change(textareaElement, {
+            target: { name: 'title', value: 'New Title' },
+        });
         await waitFor(async () => {
             const saveButton = screen.getByRole('button', { name: 'Save' });
             fireEvent.click(saveButton);
@@ -271,6 +274,25 @@ describe('TaskDetails Page', () => {
                 await screen.findByText(/Successfully saved/i)
             ).not.toBeNull();
         });
+    });
+    test('should not update the title and description with the same values', async () => {
+        server.use(...taskDetailsHandler);
+        renderWithRouter(
+            <Provider store={store()}>
+                <TaskDetails taskID={details.taskID} />
+                <ToastContainer />
+            </Provider>,
+            {}
+        );
+        const editButton = await screen.findByRole('button', { name: 'Edit' });
+        fireEvent.click(editButton);
+        const textareaElement = await screen.findByTestId('title-textarea');
+        fireEvent.change(textareaElement, {
+            target: { name: 'title', value: 'test 1 for drag and drop' },
+        });
+        const saveButton = await screen.findByRole('button', { name: 'Save' });
+        fireEvent.click(saveButton);
+        expect(screen.queryByText(/Successfully saved/i)).toBeNull();
     });
 
     test('Should render No task progress', async () => {
@@ -342,6 +364,7 @@ describe('Textarea with functionalities', () => {
         value: 'Initial value',
         onChange: mockChangeHandler,
         testId: 'textarea',
+        placeholder: '',
     };
 
     beforeEach(async () => {

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -94,8 +94,30 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
     }
     async function onSave() {
         setIsEditing(false);
+        const updatedFields: Partial<taskDetailsDataType['taskData']> = {};
+        for (const key in editedTaskDetails) {
+            if (
+                taskDetailsData &&
+                editedTaskDetails[
+                    key as keyof taskDetailsDataType['taskData']
+                ] !==
+                    taskDetailsData[
+                        key as keyof taskDetailsDataType['taskData']
+                    ]
+            ) {
+                updatedFields[key as keyof taskDetailsDataType['taskData']] =
+                    editedTaskDetails[
+                        key as keyof taskDetailsDataType['taskData']
+                    ];
+            }
+        }
+
+        if (Object.keys(updatedFields).length === 0) {
+            return;
+        }
+
         await updateTaskDetails({
-            editedDetails: editedTaskDetails,
+            editedDetails: updatedFields,
             taskID,
         })
             .unwrap()


### PR DESCRIPTION
### Issue:
- https://github.com/Real-Dev-Squad/website-status/issues/814

### Description:
Currently, if the superuser presses the save button without changing anything then there is an unnecessary patch call that is happening

### Anything you would like to inform the reviewer about:

### Dev Tested:
- [x] Yes

### Images/video of the change:

https://github.com/Real-Dev-Squad/website-status/assets/111434418/401bc114-b960-42d7-9a7a-8938e04630e0


![image](https://github.com/Real-Dev-Squad/website-status/assets/111434418/ef04bf94-2ced-445d-8f37-e6c60955bffe)

### Follow-up Issues (if any)
