### PR TITLE
Integrate Issue Assignment Form on Issues Page

### DIFF
--- a/__mocks__/db/issues.ts
+++ b/__mocks__/db/issues.ts
@@ -115,6 +115,7 @@ export const issuesResponseSearchedWithQuery = [
         body:
             '# One-Click Issue To Task Conversion- v1 Release\r\n### Closes #92 \r\n\r\nThe following sub-tasks are to be completed to release one-click issue to task conversion feature to main branch\r\n- [x] https://github.com/Dummy-Org/website-status/pull/474\r\n- [ ] #137 \r\n- [ ] #136 \r\n- [ ] [Merge website-backend changes from develop to main](https://github.com/Dummy-Org/website-backend/pull/1047)\r\n- [x] [Merge website-status changes to develop](https://github.com/Dummy-Org/website-status/pull/474)\r\n- [ ] Merge website-status changes from develop to main\r\n- [ ] Alert\r\n- [ ] Verify changes',
         taskExists: true,
+        taskId: '1234555eru478efeiu84'
     },
 ];
 

--- a/__tests__/Unit/Components/Issues/Card.test.tsx
+++ b/__tests__/Unit/Components/Issues/Card.test.tsx
@@ -6,7 +6,9 @@ import {
     issueResponseNullBody,
     issuesResponseSearchedWithQuery,
 } from '../../../../__mocks__/db/issues';
-import { renderWithProviders } from '@/test-utils/renderWithProvider';
+import { renderWithRouter } from '@/test_utils/createMockRouter';
+import { Provider } from 'react-redux';
+import { store } from '@/app/store';
 
 jest.mock('@/hooks/useUserData', () => {
     return () => ({
@@ -34,8 +36,10 @@ describe('Issue card', () => {
         expect(titleElement).toBeInTheDocument();
     });
     test('Should render issue information correctly', () => {
-        const screen = renderWithProviders(
-            <Card issue={issuesResponseSearchedWithQuery[0]} />
+        const screen = renderWithRouter(
+            <Provider store={store()}>
+                <Card issue={issuesResponseSearchedWithQuery[0]} />
+            </Provider>
         );
         expect(
             screen.getByText(issuesResponseSearchedWithQuery[0].html_url)
@@ -44,8 +48,10 @@ describe('Issue card', () => {
     });
 
     test('Should render issue created by information correctly', () => {
-        const screen = renderWithProviders(
-            <Card issue={issuesResponseSearchedWithQuery[0]} />
+        const screen = renderWithRouter(
+            <Provider store={store()}>
+                <Card issue={issuesResponseSearchedWithQuery[0]} />
+            </Provider>
         );
         const date = new Date(
             issuesResponseSearchedWithQuery[0].created_at
@@ -62,8 +68,10 @@ describe('Issue card', () => {
     });
 
     test('Should render the assignee information correctly', () => {
-        const screen = renderWithProviders(
-            <Card issue={issuesResponseSearchedWithQuery[0]} />
+        const screen = renderWithRouter(
+            <Provider store={store()}>
+                <Card issue={issuesResponseSearchedWithQuery[0]} />
+            </Provider>
         );
         const assignee = screen.getByText(
             issuesResponseSearchedWithQuery[0].assignee?.login
@@ -103,5 +111,17 @@ describe('Issue card', () => {
         expect(bodyElement).toBeInTheDocument();
         expect(markdownElement).toBeInTheDocument();
         expect(markdownElement2).toBeInTheDocument();
+    });
+
+    test('Should render action form when dev mode is enabled', () => {
+        const screen = renderWithRouter(
+            <Provider store={store()}>
+                <Card issue={issuesResponseSearchedWithQuery[0]} />
+            </Provider>,
+            {
+                query: { dev: 'true' },
+            }
+        );
+        expect(screen.getByRole('button')).toHaveTextContent('Assign Task');
     });
 });

--- a/src/components/issues/ActionForm.tsx
+++ b/src/components/issues/ActionForm.tsx
@@ -56,6 +56,7 @@ const ActionForm: FC<ActionFormProps> = ({ taskId }) => {
             >
                 Assign Task
             </button>
+            <br />
             <input
                 className={styles.assign}
                 type="text"

--- a/src/components/issues/Card.module.scss
+++ b/src/components/issues/Card.module.scss
@@ -45,6 +45,7 @@ $card-text: #78716c;
     margin-left: 0.5rem;
     margin-bottom: 1rem;
     line-height: 2rem;
+    display: inline-block;
 }
 
 .assign_label {

--- a/src/components/issues/Card.tsx
+++ b/src/components/issues/Card.tsx
@@ -7,12 +7,16 @@ import fetch from '@/helperFunctions/fetch';
 import { IssueCardProps } from '@/interfaces/issueProps.type';
 import { TASKS_URL } from '../../constants/url';
 import useUserData from '@/hooks/useUserData';
+import ActionForm from './ActionForm';
+import { useRouter } from 'next/router';
 const { SUCCESS, ERROR } = ToastTypes;
 
 const Card: FC<IssueCardProps> = ({ issue }) => {
     const date = new Date(issue.created_at).toDateString();
     const [taskExists, setTaskExists] = useState(issue.taskExists ?? false);
     const [isLoading, setIsLoading] = useState(false);
+    const router = useRouter();
+    const devMode = router.query.dev === 'true' ? true : false;
     const { isUserAuthorized } = useUserData();
 
     const getIssueInfo = () => {
@@ -119,13 +123,18 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
                 </div>
             </div>
             <div className={styles.actions}>
-                <button
-                    className={styles.card__top__button}
-                    disabled={taskExists || isLoading || !isUserAuthorized}
-                    onClick={handleClick}
-                >
-                    Convert to task
-                </button>
+                {(!taskExists || !isUserAuthorized || !devMode) && (
+                    <button
+                        className={styles.card__top__button}
+                        disabled={taskExists || isLoading || !isUserAuthorized}
+                        onClick={handleClick}
+                    >
+                        Convert to task
+                    </button>
+                )}
+                {isUserAuthorized && taskExists && devMode && (
+                    <ActionForm taskId={issue.taskId || ''} />
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
# Pull Request: Integrate Issue Assignment Form on Issues Page

### There are more iterations to this feature coming soon. like fixing the suggestion box, and disabling the assign button after the assignment. Please rest assured as I am working on them. 

## Description
This pull request addresses the requirement to integrate a form directly within the issues page for assigning issue tickets. The form will only be accessible when the "dev = true" flag is enabled.

## Changes Made
- Implemented a form component to assign issue tickets directly from the issues page.
- Added a conditional check to ensure the form is displayed only when the "dev = true" flag is enabled.

## Rationale
Integrating the assignment form within the issues page streamlines the process of assigning tickets, reducing the need to navigate to a separate assignment page. The "dev = true" flag ensures that this feature is only available to developers during the development and testing phases.

## Testing Done
- Tested the form integration and conditional display with the "dev = true" flag both enabled and disabled.
- Verified that the form functions as expected and is only accessible to developers when the flag is enabled.

## Screenshots
New look of the issues card component
![image](https://github.com/Real-Dev-Squad/website-status/assets/57758447/23eee65f-a582-4c72-905c-201854499d47)
