### PR TITLE
Fix: Display Link instead of button for git issue link in task details page.

### DIFF
--- a/__mocks__/handlers/task-details.handler.ts
+++ b/__mocks__/handlers/task-details.handler.ts
@@ -32,7 +32,7 @@ const taskDetailsHandler = [
                     },
                     github: {
                         issue: {
-                            html_url:'https://github.com/sampleOrg/sampleRepo/issues/000'
+                            html_url:'https://github.com/sample-org/sample-repo/issues/000'
                         }
                     }
                 },

--- a/__mocks__/handlers/task-details.handler.ts
+++ b/__mocks__/handlers/task-details.handler.ts
@@ -32,7 +32,7 @@ const taskDetailsHandler = [
                     },
                     github: {
                         issue: {
-                            html_url:'https://www.sampleGithubUrl.com'
+                            html_url:'https://github.com/sampleOrg/sampleRepo/issues/000'
                         }
                     }
                 },

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -129,12 +129,12 @@ describe('TaskDetails Page', () => {
             }
         );
         await waitFor(() => {
-            const gitIcon = screen.getByAltText('Git Icon');
-            expect(gitIcon).toBeInTheDocument();
+            const gitLink = screen.getByText('Issue #000');
+            expect(gitLink).toBeInTheDocument();
         });
     });
-    it('Test Open Git issue link button', async () => {
-        const { getByText } = renderWithRouter(
+    it('Test Open Git issue link', async () => {
+        const { getByLabelText } = renderWithRouter(
             <Provider store={store()}>
                 <TaskDetails taskID={details.taskID} />
             </Provider>,
@@ -143,16 +143,12 @@ describe('TaskDetails Page', () => {
             }
         );
         await waitFor(() => {
-            const button = screen.getByLabelText('Open GitHub Issue');
-            const originalOpen = window.open;
-            const mockOpen = jest.fn();
-            window.open = mockOpen;
-            fireEvent.click(button);
-            expect(mockOpen).toHaveBeenCalledWith(
-                'https://www.sampleGithubUrl.com',
-                '_blank'
+            const link = screen.getByText('Issue #000');
+            fireEvent.click(link);
+            expect(link).toHaveAttribute(
+                'href',
+                'https://github.com/sampleOrg/sampleRepo/issues/000'
             );
-            window.open = originalOpen;
         });
     });
     it('Renders Task Assignee', async () => {

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -134,7 +134,7 @@ describe('TaskDetails Page', () => {
         });
     });
     it('Test Open Git issue link', async () => {
-        const { getByLabelText } = renderWithRouter(
+        const { getByText } = renderWithRouter(
             <Provider store={store()}>
                 <TaskDetails taskID={details.taskID} />
             </Provider>,

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -147,7 +147,7 @@ describe('TaskDetails Page', () => {
             fireEvent.click(link);
             expect(link).toHaveAttribute(
                 'href',
-                'https://github.com/sampleOrg/sampleRepo/issues/000'
+                'https://github.com/sample-org/sample-repo/issues/000'
             );
         });
     });

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -12,9 +12,10 @@ const Details: FC<TaskDetailsProps> = ({ detailType, value }) => {
     const isGitHubLink = detailType === 'Link';
 
     const gitHubIssueLink = isGitHubLink ? value : undefined;
+    const issueNumberRegex = /\/issues\/(\d+)/;
 
     const extractIssueNumber = () => {
-        const issueNumberMatch = value?.match(/\/issues\/(\d+)/);
+        const issueNumberMatch = value?.match(issueNumberRegex);
         if (issueNumberMatch && issueNumberMatch.length > 1) {
             return issueNumberMatch[1];
         }

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -3,7 +3,6 @@ import setColor from './taskPriorityColors';
 import classNames from './task-details.module.scss';
 import { useRouter } from 'next/router';
 import { TaskDetailsProps } from '@/interfaces/taskDetails.type';
-import { GITHUB_LOGO } from '@/constants/url';
 
 const Details: FC<TaskDetailsProps> = ({ detailType, value }) => {
     const router = useRouter();
@@ -11,9 +10,18 @@ const Details: FC<TaskDetailsProps> = ({ detailType, value }) => {
     const isDevModeEnabled = query.dev === 'true' ? true : false;
     const color = value ? setColor?.[value] : undefined;
     const isGitHubLink = detailType === 'Link';
-    const openGitIssueLink = () => {
-        window.open(value, '_blank');
+
+    const gitHubIssueLink = isGitHubLink ? value : undefined;
+
+    const extractIssueNumber = () => {
+        const issueNumberMatch = value?.match(/\/issues\/(\d+)/);
+        if (issueNumberMatch && issueNumberMatch.length > 1) {
+            return issueNumberMatch[1];
+        }
+        return null;
     };
+
+    const issueNumber = extractIssueNumber();
 
     return (
         <div className={classNames.detailsContainer}>
@@ -23,18 +31,16 @@ const Details: FC<TaskDetailsProps> = ({ detailType, value }) => {
                 style={{ color: color ?? 'black' }}
             >
                 {isDevModeEnabled && isGitHubLink && value ? (
-                    <button
-                        className={classNames.gitButton}
+                    <a
+                        className={classNames.gitLink}
+                        href={gitHubIssueLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
                         aria-label="Open GitHub Issue"
-                        onClick={openGitIssueLink}
                         title={value}
                     >
-                        <img
-                            className={classNames.gitIcon}
-                            src={GITHUB_LOGO}
-                            alt="Git Icon"
-                        />
-                    </button>
+                        {'Issue #' + issueNumber}
+                    </a>
                 ) : (
                     <>{isGitHubLink ? 'N/A' : value ?? 'N/A'}</>
                 )}

--- a/src/components/taskDetails/task-details.module.scss
+++ b/src/components/taskDetails/task-details.module.scss
@@ -42,27 +42,8 @@ $off-white: #f0f0f0;
     }
 }
 
-.gitButton {
-    @extend .button;
-    background-color: $off-white;
-    max-height: fit-content;
-    min-width: fit-content;
-    padding: 2px;
-    padding-left: 8px;
-    padding-right: 8px;
-    &:hover {
-        background-color: white;
-    }
-
-    .icon {
-        width: 12px;
-        height: 12px;
-    }
-
-    .gitIcon {
-        @extend .icon;
-        filter: invert(100%);
-    }
+.gitLink {
+    color: $theme-blue;
 }
 
 .detailsContainer {


### PR DESCRIPTION
### Issue:
Main issue: #774 
This is a follow-up PR of #827 to resolve review comments.

Review comments:
1) Use Link instead of button
2) Write proper CSS.

### Description:
Changes : 
1) A link is used instead of a button for displaying the git issue link on the task details page.
2) Modified the tests accordingly for the link.
3) Removed unused CSS.


### Anything you would like to inform the reviewer about:
A review comment in earlier PR was to use single line. But this formatting is done by Prettier so I could not add it in a single line.
[src/components/taskDetails/index.tsx](https://github.com/Real-Dev-Squad/website-status/pull/827/files/0c3718f538f764b7785fd4a296ab20a23848371a#diff-543be524388e0f526cb5ff91b3af518cf41ed9175d95a349a074418e508cc298)

### Dev Tested:
- [ ✓] Yes


### Images/video of the change:
Before :
![image](https://github.com/Real-Dev-Squad/website-status/assets/41846637/65b54967-50f3-4e3a-b66b-03cc2b45d9c0)

After:
![image](https://github.com/Real-Dev-Squad/website-status/assets/41846637/12afd9ff-04e0-4e20-99de-d54bb887e93e)

[gitIssue2.webm](https://github.com/Real-Dev-Squad/website-status/assets/41846637/e696e4b6-5f59-4059-8809-99d41a44637d)

### Follow-up Issues (if any)
No

### Test Stat
Before:
![image](https://github.com/Real-Dev-Squad/website-status/assets/41846637/7d90ccac-5702-46dc-962a-bcaf5ef72cb1)

After:
![image](https://github.com/Real-Dev-Squad/website-status/assets/41846637/4eee150e-3c99-4224-b613-7bfc2f592345)
