### PR TITLE
Changing task status to DONE and UNASSIGNED

### DIFF
--- a/__mocks__/db/tasks.ts
+++ b/__mocks__/db/tasks.ts
@@ -131,6 +131,26 @@ const PAGINATED_TASKS = {
       status: 'AVAILABLE',
       title: 'Implement user authentication and authorization',
       dependsOn: []
+    },
+    {
+      id: 'AB6Y1hVrS0zR5ZcVPwYZ',
+      percentCompleted: 100,
+      isNoteworthy: false,
+      createdBy: 'sahsi',
+      lossRate: {
+        dinero: 100,
+        neelam: 0
+      },
+      assignee: false,
+      type: 'feature',
+      priority: 'HIGH',
+      completionAward: {
+        dinero: 1000,
+        neelam: 0
+      },
+      status: 'DONE',
+      title: 'Depreciate task status AVAILABLE and COMPLETED',
+      dependsOn: []
     }
   ],
   prev: '/tasks?status=AVAILABLE&dev=true&size=5&prev=ARn1G8IxUt1zrfMdTyfn',

--- a/__tests__/Unit/Components/Tabs/Tab.test.tsx
+++ b/__tests__/Unit/Components/Tabs/Tab.test.tsx
@@ -63,6 +63,22 @@ describe('Tabs Component', () => {
         expect(onSelectMock).toHaveBeenCalledWith(Tab.ASSIGNED);
     });
 
+    it('check if selectTab() is called with right key when dev is true', () => {
+        render(
+            <Tabs
+                dev={true}
+                tabs={TABS}
+                activeTab={Tab.UNASSIGNED}
+                onSelect={onSelectMock}
+            />
+        );
+        const unassignedBtn = screen.getByRole('button', {
+            name: 'UNASSIGNED',
+        });
+        fireEvent.click(unassignedBtn);
+        expect(onSelectMock).toHaveBeenCalledWith(Tab.UNASSIGNED);
+    });
+
     it('Check if correct button is selected', () => {
         render(
             <Tabs

--- a/__tests__/Unit/Components/Tabs/Tab.test.tsx
+++ b/__tests__/Unit/Components/Tabs/Tab.test.tsx
@@ -1,13 +1,18 @@
 import Tabs from '@/components/Tabs';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Tab, TABS } from '@/interfaces/task.type';
-import { COMPLETED, DONE, AVAILABLE, UNASSINGED } from '@/constants/constants';
+import {
+    Tab,
+    TABS,
+    depreciatedTaskStatus,
+    newTaskStatus,
+} from '@/interfaces/task.type';
+import { COMPLETED, DONE, AVAILABLE, UNASSIGNED } from '@/constants/constants';
 
 function changeName(name: string) {
     if (name === COMPLETED) {
         return DONE;
     } else if (name === AVAILABLE) {
-        return UNASSINGED;
+        return UNASSIGNED;
     } else {
         return name.split('_').join(' ');
     }
@@ -25,7 +30,24 @@ describe('Tabs Component', () => {
             />
         );
         const presentTabs = screen.queryAllByRole('button');
-        expect(presentTabs.length).toBe(TABS.length);
+        expect(presentTabs.length).toBe(
+            TABS.filter((tab) => !newTaskStatus.includes(tab)).length
+        );
+    });
+
+    it('should render all the buttons when dev is true', () => {
+        render(
+            <Tabs
+                dev={true}
+                tabs={TABS}
+                activeTab={Tab.ASSIGNED}
+                onSelect={onSelectMock}
+            />
+        );
+        const presentTabs = screen.queryAllByRole('button');
+        expect(presentTabs.length).toBe(
+            TABS.filter((tab) => !depreciatedTaskStatus.includes(tab)).length
+        );
     });
 
     it('check if selectTab() is called with right key', () => {
@@ -36,7 +58,7 @@ describe('Tabs Component', () => {
                 onSelect={onSelectMock}
             />
         );
-        const assignedBtn = screen.getByRole('button', { name: /ASSIGNED/i });
+        const assignedBtn = screen.getByRole('button', { name: 'ASSIGNED' });
         fireEvent.click(assignedBtn);
         expect(onSelectMock).toHaveBeenCalledWith(Tab.ASSIGNED);
     });
@@ -53,6 +75,21 @@ describe('Tabs Component', () => {
         expect(completedBtn).toHaveClass('active');
     });
 
+    it('Check if correct button is selected when dev is true', () => {
+        render(
+            <Tabs
+                dev={true}
+                tabs={TABS}
+                activeTab={Tab.UNASSIGNED}
+                onSelect={onSelectMock}
+            />
+        );
+        const unassignedBtn = screen.getByRole('button', {
+            name: /UNASSIGNED/i,
+        });
+        expect(unassignedBtn).toHaveClass('active');
+    });
+
     it('should render all tabs passed with correct text', () => {
         render(
             <Tabs
@@ -62,8 +99,27 @@ describe('Tabs Component', () => {
             />
         );
         const presentTabs = screen.getAllByRole('button');
+        const OLDTABS = TABS.filter((tab) => !newTaskStatus.includes(tab));
         for (let i = 0; i < presentTabs.length; i++) {
-            expect(presentTabs[i].textContent).toBe(changeName(TABS[i]));
+            expect(presentTabs[i].textContent).toBe(changeName(OLDTABS[i]));
+        }
+    });
+
+    it('should render all tabs passed with correct text when dev is true', () => {
+        render(
+            <Tabs
+                dev={true}
+                tabs={TABS}
+                activeTab={Tab.ASSIGNED}
+                onSelect={onSelectMock}
+            />
+        );
+        const presentTabs = screen.getAllByRole('button');
+        const NEWTABS = TABS.filter(
+            (tab) => !depreciatedTaskStatus.includes(tab)
+        );
+        for (let i = 0; i < presentTabs.length; i++) {
+            expect(presentTabs[i].textContent).toBe(changeName(NEWTABS[i]));
         }
     });
 });

--- a/__tests__/Unit/Components/Tasks/FilterModal.test.tsx
+++ b/__tests__/Unit/Components/Tasks/FilterModal.test.tsx
@@ -30,6 +30,30 @@ describe('FilterModal', () => {
         expect(inProgressButton).toBeInTheDocument();
     });
 
+    test('renders the modal with correct title and buttons when dev is true', () => {
+        render(
+            <FilterModal
+                dev={true}
+                tabs={[Tab.UNASSIGNED, Tab.DONE]}
+                onSelect={mockOnSelect}
+                activeTab={Tab.UNASSIGNED}
+                onClose={mockOnClose}
+            />
+        );
+
+        const modalTitle = screen.getByText('Filter');
+        expect(modalTitle).toBeInTheDocument();
+
+        const closeButton = screen.getByText('×');
+        expect(closeButton).toBeInTheDocument();
+
+        const unassignedButton = screen.getByText(/unassigned/i);
+        expect(unassignedButton).toBeInTheDocument();
+
+        const doneButton = screen.getByText(/done/i);
+        expect(doneButton).toBeInTheDocument();
+    });
+
     test('calls onSelect and onClose when a status button is clicked', () => {
         render(
             <FilterModal
@@ -77,5 +101,23 @@ describe('FilterModal', () => {
 
         const inProgressButton = screen.getByText(/in progress/i);
         expect(inProgressButton).not.toHaveClass('status-button-active');
+    });
+
+    test('renders the modal with correct active tab when dev is true', () => {
+        render(
+            <FilterModal
+                dev={true}
+                tabs={[Tab.UNASSIGNED, Tab.DONE]}
+                onSelect={mockOnSelect}
+                activeTab={Tab.DONE}
+                onClose={mockOnClose}
+            />
+        );
+
+        const doneButton = screen.getByText(/done/i);
+        expect(doneButton).toHaveClass('status-button-active');
+
+        const unassignedButton = screen.getByText(/unassigned/i);
+        expect(unassignedButton).not.toHaveClass('status-button-active');
     });
 });

--- a/__tests__/Unit/Components/Tasks/TaskSearch.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskSearch.test.tsx
@@ -84,6 +84,26 @@ describe('TaskSearch', () => {
         expect(onInputChange).toHaveBeenCalledWith('is:merged');
     });
 
+    test('calls onInputChange when the search input value changes when dev is true', () => {
+        const onSelect = jest.fn();
+        const onInputChange = jest.fn();
+        const onClickSearchButton = jest.fn();
+
+        render(
+            <TaskSearch
+                dev={true}
+                onSelect={onSelect}
+                inputValue=""
+                onInputChange={onInputChange}
+                onClickSearchButton={onClickSearchButton}
+            />
+        );
+
+        const searchInput = screen.getByTestId('search-input');
+        fireEvent.change(searchInput, { target: { value: 'is:done' } });
+        expect(onInputChange).toHaveBeenCalledWith('is:done');
+    });
+
     test('calls onSelect when the any one filter button is clicked', () => {
         const onSelect = jest.fn();
         const onInputChange = jest.fn();
@@ -102,6 +122,27 @@ describe('TaskSearch', () => {
         const assignedButton = screen.getByText(/assigned/i);
         fireEvent.click(assignedButton);
         expect(onSelect).toHaveBeenCalledWith('ASSIGNED');
+    });
+
+    test('calls onSelect when the any one filter button is clicked and dev is true', () => {
+        const onSelect = jest.fn();
+        const onInputChange = jest.fn();
+        const onClickSearchButton = jest.fn();
+
+        render(
+            <TaskSearch
+                dev={true}
+                onSelect={onSelect}
+                inputValue=""
+                onInputChange={onInputChange}
+                onClickSearchButton={onClickSearchButton}
+            />
+        );
+        const filterButton = screen.getByText('Filter');
+        fireEvent.click(filterButton);
+        const unassignedButton = screen.getByText(/unassigned/i);
+        fireEvent.click(unassignedButton);
+        expect(onSelect).toHaveBeenCalledWith('UNASSIGNED');
     });
 
     test('calls onClickSearchButton when enter key is pressed', () => {

--- a/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
@@ -69,6 +69,28 @@ describe('tasks content', () => {
         expect(screen.getByText(NO_TASKS_FOUND_MESSAGE)).toBeInTheDocument();
     });
 
+    test('select tab and set active when dev is true', async () => {
+        setWindowInnerWidth(breakpointToShowTabs);
+        renderWithRouter(
+            <Provider store={store()}>
+                <TasksContent dev={true} />
+            </Provider>,
+            {
+                query: { section: 'unassigned' },
+            }
+        );
+        await screen.findByTestId('tabs');
+        const tabsContainer = within(
+            screen.getByTestId('status-tabs-container')
+        );
+        const assignedButton = tabsContainer.getByRole('button', {
+            name: 'UNASSIGNED',
+        });
+        expect(assignedButton).toHaveTextContent('UNASSIGNED');
+        await screen.findByText(NO_TASKS_FOUND_MESSAGE);
+        expect(screen.getByText(NO_TASKS_FOUND_MESSAGE)).toBeInTheDocument();
+    });
+
     test('displays "No tasks found" message when there are no tasks', async () => {
         server.use(noTasksFoundHandler);
         const { findByText } = renderWithRouter(

--- a/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TasksContent.test.tsx
@@ -62,7 +62,7 @@ describe('tasks content', () => {
             screen.getByTestId('status-tabs-container')
         );
         const assignedButton = tabsContainer.getByRole('button', {
-            name: /assigned/i,
+            name: 'ASSIGNED',
         });
         expect(assignedButton).toHaveTextContent('ASSIGNED');
         await screen.findByText(NO_TASKS_FOUND_MESSAGE);
@@ -95,6 +95,21 @@ describe('tasks content', () => {
         expect(task).toBeInTheDocument();
     });
 
+    test('display tasks when dev is true', async () => {
+        const { findByText } = renderWithRouter(
+            <Provider store={store()}>
+                <TasksContent dev={true} />
+            </Provider>,
+            { query: { section: 'done' } }
+        );
+        await screen.findByTestId('tabs');
+
+        const task = await findByText(
+            'Depreciate task status AVAILABLE and COMPLETED'
+        );
+        expect(task).toBeInTheDocument();
+    });
+
     test('Selecting a tab pushes into query params', async () => {
         setWindowInnerWidth(breakpointToShowTabs);
         const mockPushFunction = jest.fn();
@@ -114,13 +129,43 @@ describe('tasks content', () => {
         });
         expect(inProgressBtn).toHaveClass('tabButton');
         const unassignedButton = tabsContainer.getByRole('button', {
-            name: /UNASSINGED/i,
+            name: /UNASSIGNED/i,
         });
         fireEvent.click(unassignedButton);
         expect(mockPushFunction).toBeCalledTimes(1);
         expect(mockPushFunction).toBeCalledWith({
             query: {
                 q: 'status:available',
+            },
+        });
+    });
+
+    test('Selecting a tab pushes into query params when dev is true', async () => {
+        setWindowInnerWidth(breakpointToShowTabs);
+        const mockPushFunction = jest.fn();
+        renderWithRouter(
+            <Provider store={store()}>
+                <TasksContent dev={true} />
+            </Provider>,
+            { push: mockPushFunction }
+        );
+
+        await screen.findByTestId('tabs');
+        const tabsContainer = within(
+            screen.getByTestId('status-tabs-container')
+        );
+        const inProgressBtn = tabsContainer.getByRole('button', {
+            name: /IN PROGRESS/i,
+        });
+        expect(inProgressBtn).toHaveClass('tabButton');
+        const unassignedButton = tabsContainer.getByRole('button', {
+            name: /UNASSIGNED/i,
+        });
+        fireEvent.click(unassignedButton);
+        expect(mockPushFunction).toBeCalledTimes(1);
+        expect(mockPushFunction).toBeCalledWith({
+            query: {
+                q: 'status:unassigned',
             },
         });
     });
@@ -191,6 +236,50 @@ describe('tasks content', () => {
         });
     });
 
+    test('Selecting a value from dropdown pushes into query params when dev is true', async () => {
+        setWindowInnerWidth(breakpointToShowSelect);
+        const mockPushFunction = jest.fn();
+        renderWithRouter(
+            <Provider store={store()}>
+                <TasksContent dev={true} />
+            </Provider>,
+            { push: mockPushFunction }
+        );
+
+        await screen.findByTestId('status-select-container');
+        const selectContainer = screen?.getByTestId(
+            'selected-option-container'
+        );
+
+        fireEvent.click(selectContainer);
+        fireEvent.keyDown(selectContainer, {
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+        });
+
+        fireEvent.keyDown(selectContainer, {
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+        });
+
+        fireEvent.keyDown(selectContainer, {
+            key: 'ArrowDown',
+            code: 'ArrowDown',
+        });
+
+        fireEvent.keyDown(selectContainer, {
+            key: 'Enter',
+            code: 'Enter',
+        });
+
+        expect(mockPushFunction).toBeCalledTimes(1);
+        expect(mockPushFunction).toBeCalledWith({
+            query: {
+                q: 'status:unassigned',
+            },
+        });
+    });
+
     test('searchButtonHandler when search button is clicked', async () => {
         setWindowInnerWidth(breakpointToShowTabs);
         const mockPushFunction = jest.fn();
@@ -247,7 +336,7 @@ describe('tasks content', () => {
             screen.getByTestId('status-tabs-container')
         );
         const assignedButton = tabsContainer.getByRole('button', {
-            name: /assigned/i,
+            name: 'ASSIGNED',
         });
         fireEvent.click(assignedButton);
         expect(mockPushFunction).toBeCalledTimes(1);

--- a/__tests__/Unit/utils/getActiveTab.test.ts
+++ b/__tests__/Unit/utils/getActiveTab.test.ts
@@ -6,11 +6,13 @@ describe('Unit | Util | Get Active Tab', () => {
         expect(getActiveTab()).toEqual(Tab.ALL);
         expect(getActiveTab('assigned')).toEqual(Tab.ASSIGNED);
         expect(getActiveTab('available')).toEqual(Tab.AVAILABLE);
+        expect(getActiveTab('unassigned')).toEqual(Tab.UNASSIGNED);
         expect(getActiveTab('needs-review')).toEqual(Tab.NEEDS_REVIEW);
         expect(getActiveTab('in-review')).toEqual(Tab.IN_REVIEW);
         expect(getActiveTab('verified')).toEqual(Tab.VERIFIED);
         expect(getActiveTab('merged')).toEqual(Tab.MERGED);
         expect(getActiveTab('completed')).toEqual(Tab.COMPLETED);
+        expect(getActiveTab('done')).toEqual(Tab.DONE);
         expect(getActiveTab('in-progress')).toEqual(Tab.IN_PROGRESS);
         expect(getActiveTab('someRandomSection')).toEqual(Tab.ALL);
     });

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 import styles from './select.module.scss';
 import { SelectOption, SelectProps } from '@/types/Select';
+import { depreciatedTaskStatus, newTaskStatus } from '@/interfaces/task.type';
 
-export function Select({ value, onChange, options }: SelectProps) {
+export function Select({ value, onChange, options, dev }: SelectProps) {
+    options = options.filter((option: SelectOption) =>
+        dev
+            ? !depreciatedTaskStatus.includes(option.value.toString())
+            : !newTaskStatus.includes(option.value.toString())
+    );
     const [isOpen, setIsOpen] = useState(false);
     const [highlightedIndex, setHighlightedIndex] = useState(0);
     const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,26 +1,37 @@
 import styles from '@/components/Tabs/Tabs.module.scss';
-import { Tab } from '@/interfaces/task.type';
+import {
+    Tab,
+    depreciatedTaskStatus,
+    newTaskStatus,
+} from '@/interfaces/task.type';
 import { getChangedStatusName } from '@/utils/getChangedStatusName';
 
 type TabsProps = {
     tabs: Tab[];
     onSelect: (tab: Tab) => void;
     activeTab: Tab;
+    dev?: boolean;
 };
 
-const Tabs = ({ tabs, onSelect, activeTab }: TabsProps) => (
+const Tabs = ({ dev, tabs, onSelect, activeTab }: TabsProps) => (
     <>
-        {tabs.map((tab: Tab) => (
-            <button
-                key={tab}
-                onClick={() => onSelect(tab)}
-                className={`${styles.tabButton} ${
-                    activeTab === tab ? styles.active : ''
-                }`}
-            >
-                {getChangedStatusName(tab)}
-            </button>
-        ))}
+        {tabs
+            .filter((tab: Tab) =>
+                dev
+                    ? !depreciatedTaskStatus.includes(tab)
+                    : !newTaskStatus.includes(tab)
+            )
+            .map((tab: Tab) => (
+                <button
+                    key={tab}
+                    onClick={() => onSelect(tab)}
+                    className={`${styles.tabButton} ${
+                        activeTab === tab ? styles.active : ''
+                    }`}
+                >
+                    {getChangedStatusName(tab)}
+                </button>
+            ))}
     </>
 );
 

--- a/src/components/tasks/TabSection.tsx
+++ b/src/components/tasks/TabSection.tsx
@@ -4,13 +4,16 @@ import Tabs from '../Tabs';
 export const TabSection = ({
     onSelect,
     activeTab,
+    dev,
 }: {
     onSelect: (tab: Tab) => void;
     activeTab: Tab;
+    dev?: boolean;
 }) => {
     return (
         <div className={classNames.tabsContainer} data-testid="tabs">
             <Tabs
+                dev={dev}
                 tabs={TABS as Tab[]}
                 onSelect={onSelect}
                 activeTab={activeTab}

--- a/src/components/tasks/TaskSearch/FilterModal.tsx
+++ b/src/components/tasks/TaskSearch/FilterModal.tsx
@@ -1,5 +1,9 @@
 import className from './tasksearch.module.scss';
-import { Tab } from '@/interfaces/task.type';
+import {
+    Tab,
+    depreciatedTaskStatus,
+    newTaskStatus,
+} from '@/interfaces/task.type';
 import { getChangedStatusName } from '@/utils/getChangedStatusName';
 
 type FilterModalProps = {
@@ -7,6 +11,7 @@ type FilterModalProps = {
     onSelect: (tab: Tab) => void;
     activeTab?: Tab;
     onClose: () => void;
+    dev?: boolean;
 };
 
 const FilterModal = ({
@@ -14,6 +19,7 @@ const FilterModal = ({
     onSelect,
     activeTab,
     onClose,
+    dev,
 }: FilterModalProps) => {
     return (
         <div className={className['filter-modal']} data-testid="filter-modal">
@@ -24,22 +30,28 @@ const FilterModal = ({
                 </span>
             </div>
             <div className={className['status-filter']}>
-                {tabs.map((tab) => (
-                    <button
-                        key={tab}
-                        className={`${className['status-button']} ${
-                            activeTab === tab
-                                ? className['status-button-active']
-                                : ''
-                        }`}
-                        onClick={() => {
-                            onSelect(tab);
-                            onClose();
-                        }}
-                    >
-                        {getChangedStatusName(tab)}
-                    </button>
-                ))}
+                {tabs
+                    .filter((tab: Tab) =>
+                        dev
+                            ? !depreciatedTaskStatus.includes(tab)
+                            : !newTaskStatus.includes(tab)
+                    )
+                    .map((tab) => (
+                        <button
+                            key={tab}
+                            className={`${className['status-button']} ${
+                                activeTab === tab
+                                    ? className['status-button-active']
+                                    : ''
+                            }`}
+                            onClick={() => {
+                                onSelect(tab);
+                                onClose();
+                            }}
+                        >
+                            {getChangedStatusName(tab)}
+                        </button>
+                    ))}
             </div>
         </div>
     );

--- a/src/components/tasks/TaskSearch/TaskSearch.tsx
+++ b/src/components/tasks/TaskSearch/TaskSearch.tsx
@@ -9,6 +9,7 @@ type TaskSearchProps = {
     activeTab?: Tab;
     onInputChange: (value: string) => void;
     onClickSearchButton: () => void;
+    dev?: boolean;
 };
 
 const TaskSearch = ({
@@ -17,6 +18,7 @@ const TaskSearch = ({
     activeTab,
     onInputChange,
     onClickSearchButton,
+    dev,
 }: TaskSearchProps) => {
     const [modalOpen, setModalOpen] = useState(false);
 
@@ -38,6 +40,7 @@ const TaskSearch = ({
                     Filter
                     {modalOpen && (
                         <FilterModal
+                            dev={dev}
                             tabs={TABS as Tab[]}
                             onSelect={onSelect}
                             activeTab={activeTab}

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -23,7 +23,7 @@ import { getChangedStatusName } from '@/utils/getChangedStatusName';
 import useIntersection from '@/hooks/useIntersection';
 import TaskSearch from './TaskSearch/TaskSearch';
 
-export const TasksContent = () => {
+export const TasksContent = ({ dev }: { dev?: boolean }) => {
     const router = useRouter();
     const qQueryParam = router.query.q as string;
     const extractedValues = extractQueryParams(qQueryParam);
@@ -38,11 +38,13 @@ export const TasksContent = () => {
         IN_PROGRESS: [],
         ASSIGNED: [],
         AVAILABLE: [],
+        UNASSIGNED: [],
         NEEDS_REVIEW: [],
         IN_REVIEW: [],
         VERIFIED: [],
         MERGED: [],
         COMPLETED: [],
+        DONE: [],
     });
     const loadingRef = useRef<ElementRef<'div'>>(null);
     const [inputValue, setInputValue] = useState<string>(
@@ -129,11 +131,13 @@ export const TasksContent = () => {
             IN_PROGRESS: [],
             ASSIGNED: [],
             AVAILABLE: [],
+            UNASSIGNED: [],
             NEEDS_REVIEW: [],
             IN_REVIEW: [],
             VERIFIED: [],
             MERGED: [],
             COMPLETED: [],
+            DONE: [],
         });
         inputValue && onSelect(status as Tab, assignee, title);
     };
@@ -145,6 +149,7 @@ export const TasksContent = () => {
     return (
         <div className={classNames.tasksContainer}>
             <TaskSearch
+                dev={dev}
                 onSelect={(selectedTab: Tab) =>
                     onSelect(selectedTab, queryAssignee, queryTitle)
                 }
@@ -158,6 +163,7 @@ export const TasksContent = () => {
                 data-testid="status-tabs-container"
             >
                 <TabSection
+                    dev={dev}
                     onSelect={(status: Tab) =>
                         onSelect(status, queryAssignee, queryTitle)
                     }
@@ -169,6 +175,7 @@ export const TasksContent = () => {
                 data-testid="status-select-container"
             >
                 <Select
+                    dev={dev}
                     value={{
                         label: getChangedStatusName(selectedTab),
                         value: selectedTab,

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -4,7 +4,7 @@ export const STANDUP_SUBMISSION_SUCCESS = 'Standup submitted successfully';
 export const COMPLETED = 'COMPLETED';
 export const DONE = 'DONE';
 export const AVAILABLE = 'AVAILABLE';
-export const UNASSINGED = 'UNASSINGED';
+export const UNASSIGNED = 'UNASSIGNED';
 export const PROGRESS_SUCCESSFUL = 'Progress Updated Successfully';
 export const STANDUP_ALREADY_SUBMITTED =
     'Standup already submitted for the day';

--- a/src/interfaces/task.type.ts
+++ b/src/interfaces/task.type.ts
@@ -82,11 +82,13 @@ enum Tab {
     IN_PROGRESS = 'IN_PROGRESS',
     ASSIGNED = 'ASSIGNED',
     AVAILABLE = 'AVAILABLE',
+    UNASSIGNED = 'UNASSIGNED',
     NEEDS_REVIEW = 'NEEDS_REVIEW',
     IN_REVIEW = 'IN_REVIEW',
     VERIFIED = 'VERIFIED',
     MERGED = 'MERGED',
     COMPLETED = 'COMPLETED',
+    DONE = 'DONE',
 }
 
 const TABS = Object.values(Tab);
@@ -124,11 +126,13 @@ export type TabTasksData = {
     IN_PROGRESS: task[];
     ASSIGNED: task[];
     AVAILABLE: task[];
+    UNASSIGNED: task[];
     NEEDS_REVIEW: task[];
     IN_REVIEW: task[];
     VERIFIED: task[];
     MERGED: task[];
     COMPLETED: task[];
+    DONE: task[];
 };
 
 export type CardTaskDetails = task & {
@@ -136,3 +140,6 @@ export type CardTaskDetails = task & {
     savingDate: string;
     savingText: string;
 };
+
+export const depreciatedTaskStatus = ['AVAILABLE', 'COMPLETED'];
+export const newTaskStatus = ['UNASSIGNED', 'DONE'];

--- a/src/pages/tasks/index.tsx
+++ b/src/pages/tasks/index.tsx
@@ -4,13 +4,13 @@ import classNames from '@/styles/tasks.module.scss';
 import { TasksContent } from '@/components/tasks/TasksContent';
 import { NextPageContext } from 'next';
 
-function Tasks() {
+function Tasks({ dev }: { dev?: boolean }) {
     return (
         <Layout>
             <Head title="Tasks" />
 
             <div className={classNames.container}>
-                <TasksContent />
+                <TasksContent dev={dev} />
             </div>
         </Layout>
     );

--- a/src/types/Select.d.ts
+++ b/src/types/Select.d.ts
@@ -10,4 +10,5 @@ export type SingleSelectProps = {
 
 export type SelectProps = {
     options: SelectOption[];
+    dev?: boolean;
 } & SingleSelectProps;

--- a/src/utils/getActiveTab.ts
+++ b/src/utils/getActiveTab.ts
@@ -8,6 +8,8 @@ export const getActiveTab = (section?: string): Tab => {
             return Tab.ASSIGNED;
         case 'available':
             return Tab.AVAILABLE;
+        case 'unassigned':
+            return Tab.UNASSIGNED;
         case 'needs-review':
             return Tab.NEEDS_REVIEW;
         case 'in-review':
@@ -18,6 +20,8 @@ export const getActiveTab = (section?: string): Tab => {
             return Tab.MERGED;
         case 'completed':
             return Tab.COMPLETED;
+        case 'done':
+            return Tab.DONE;
         default:
             return Tab.ALL;
     }

--- a/src/utils/getChangedStatusName.ts
+++ b/src/utils/getChangedStatusName.ts
@@ -1,9 +1,9 @@
-import { COMPLETED, DONE, AVAILABLE, UNASSINGED } from '@/constants/constants';
+import { COMPLETED, DONE, AVAILABLE, UNASSIGNED } from '@/constants/constants';
 export function getChangedStatusName(name: string) {
     if (name === COMPLETED) {
         return DONE;
     } else if (name === AVAILABLE) {
-        return UNASSINGED;
+        return UNASSIGNED;
     } else {
         return name.split('_').join(' ');
     }


### PR DESCRIPTION
### Issue: #800 

As `AVAILABLE` and `COMPLETED` task status are being depreciated and `UNASSIGNED` and `DONE` are to be added to status site. When `UNASSIGNED` or `DONE` is clicked we'll retrieve tasks with status `UNASSIGNED` or `DONE` respectively.
This is under feature flag.

- Changes are made to retrieve tasks with status `UNASSIGNED` when `UNASSIGNED` is clicked.
- Changes are made to retrieve tasks with status `DONE` when `DONE` is clicked.

### Dev Tested:
- [X] Yes

### Before Changes:
https://github.com/Real-Dev-Squad/website-status/assets/77037622/b2ef5a0b-678d-455e-a70b-e04f4a951245

### After Changes:
https://github.com/Real-Dev-Squad/website-status/assets/77037622/a83da599-90fa-42d3-be06-1974e0323b12

### Test coverage:
<img width="456" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/77037622/1898dbbb-e791-4371-a8ca-3487326b58e5">
<img width="461" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/77037622/262083d7-d792-4737-8d80-0bedd1458f22">
<img width="545" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/77037622/30794b92-42e6-4bf6-8978-90f059218d27">
<img width="559" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/77037622/9d51afa3-10fc-4e40-a988-471c2eb536e8">

<img width="679" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/77037622/75f0e20e-e17f-4867-93f2-6c1323d65581">
<img width="680" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/77037622/61b3c06a-fa51-470e-b302-0415bb889ea2">
<img width="736" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/77037622/36e2a333-8046-43d8-b7ba-c31b8a6a5782">
<img width="678" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/77037622/e5a6dd85-f695-4813-ac91-1919a7d14902">

### Follow-up Issues (if any)
