### PR TITLE
Fix: Disable Task request button on assigned tasks.

### DIFF
--- a/__mocks__/handlers/task-details.handler.ts
+++ b/__mocks__/handlers/task-details.handler.ts
@@ -70,6 +70,42 @@ const taskDetailsHandler = [
             })
         );
     }),
+    rest.get(`${URL}/tasks/6KhcLU3yr45dzjQIVm0l/details`, (_, res, ctx) => {
+        return res(
+            ctx.status(200),
+            ctx.json({
+                message: 'task returned successfully',
+                taskData: {
+                    id: '6KhcLU3yr45dzjQIVm0l',
+                    isNoteworthy: true,
+                    lossRate: {
+                        dinero: 0,
+                        neelam: 0,
+                    },
+                    endsOn: 1618790410,
+                    title: 'test 1 for drag and drop',
+                    status: 'in_progress',
+                    assignee: 'ankur',
+                    links: ['null'],
+                    dependsOn: ['null'],
+                    percentCompleted: 0,
+                    type: 'feature',
+                    priority: 'high',
+                    featureUrl: 'https://www.sampleUrl.com',
+                    startedOn: 1617062400,
+                    completionAward: {
+                        neelam: 0,
+                        dinero: 110,
+                    },
+                    github: {
+                        issue: {
+                            html_url:'https://github.com/sample-org/sample-repo/issues/000'
+                        }
+                    },
+                },
+            })
+        );
+    }),
     rest.patch(`${URL}/tasks/:taskId`, (_, res, ctx) => {
         return res(ctx.status(204));
     }),

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -119,6 +119,42 @@ describe('TaskDetails Page', () => {
             expect(getByText('assigned')).toBeInTheDocument();
         });
     });
+    it('check if Request for Task button is disabled for ASSIGNED task', async () => {
+        renderWithRouter(
+            <Provider store={store()}>
+                <TaskDetails taskID={details.taskID} />
+            </Provider>,
+            { query: { dev: 'true' } }
+        );
+
+        await waitFor(() => {
+            const requestForTaskButton = screen.getByTestId(
+                'request-task-button'
+            );
+            expect(requestForTaskButton).toBeInTheDocument();
+            expect(requestForTaskButton).toBeDisabled();
+        });
+    });
+    it('check if Request for Task button is not disabled for IN_PROGRESS task', async () => {
+        const testTaskDetails = {
+            url: 'https://realdevsquad.com/tasks/6KhcLU3yr45dzjQIVm0l/details',
+            taskID: '6KhcLU3yr45dzjQIVm0l',
+        };
+        renderWithRouter(
+            <Provider store={store()}>
+                <TaskDetails taskID={testTaskDetails.taskID} />
+            </Provider>,
+            { query: { dev: 'true' } }
+        );
+
+        await waitFor(() => {
+            const requestForTaskButton = screen.getByTestId(
+                'request-task-button'
+            );
+            expect(requestForTaskButton).toBeInTheDocument();
+            expect(requestForTaskButton).not.toBeDisabled();
+        });
+    });
     it('Renders Task Link open button', async () => {
         const { getByText } = renderWithRouter(
             <Provider store={store()}>
@@ -495,9 +531,13 @@ describe('Task Details > Task Request', () => {
     });
 
     it('Success toast should be shown on success', async () => {
+        const testTaskDetails = {
+            url: 'https://realdevsquad.com/tasks/6KhcLU3yr45dzjQIVm0l/details',
+            taskID: '6KhcLU3yr45dzjQIVm0l',
+        };
         renderWithRouter(
             <Provider store={store()}>
-                <TaskDetails taskID={details.taskID} />
+                <TaskDetails taskID={testTaskDetails.taskID} />
                 <ToastContainer />
             </Provider>,
             { query: { dev: 'true' } }
@@ -519,11 +559,15 @@ describe('Task Details > Task Request', () => {
     });
 
     it('Error toast should be shown on error', async () => {
+        const testTaskDetails = {
+            url: 'https://realdevsquad.com/tasks/6KhcLU3yr45dzjQIVm0l/details',
+            taskID: '6KhcLU3yr45dzjQIVm0l',
+        };
         server.use(...taskRequestErrorHandler);
 
         renderWithRouter(
             <Provider store={store()}>
-                <TaskDetails taskID={details.taskID} />
+                <TaskDetails taskID={testTaskDetails.taskID} />
                 <ToastContainer />
             </Provider>,
             { query: { dev: 'true' } }

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -354,6 +354,10 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
                                             data-testid="request-task-button"
                                             className={classNames.button}
                                             onClick={taskRequestHandle}
+                                            disabled={
+                                                taskDetailsData?.status.toUpperCase() ===
+                                                'ASSIGNED'
+                                            }
                                         >
                                             Request for task
                                         </button>

--- a/src/components/taskDetails/task-details.module.scss
+++ b/src/components/taskDetails/task-details.module.scss
@@ -42,6 +42,13 @@ $off-white: #f0f0f0;
     }
 }
 
+.button[disabled] {
+    background-color: transparent;
+    color: $light-black;
+    cursor: not-allowed;
+    border: 1px solid $light-black;
+}
+
 .gitLink {
     color: $theme-blue;
 }


### PR DESCRIPTION
### Issue:
#867 
The "Request for task" button should not be enabled for assigned tasks as highlighted in the image below.

Image:
![image](https://github.com/Real-Dev-Squad/website-status/assets/41846637/016fd6c1-d6a1-41d0-81b8-ddd7128ccbd1)

### Description:
Disabled the "Request for task" button when the task status is "ASSIGNED".
Added tests to check if the button is enabled or disabled for different task status.

### Anything you would like to inform the reviewer about:
No

### Dev Tested:
- [✓ ] Yes


### Images/video of the change:
![image](https://github.com/Real-Dev-Squad/website-status/assets/41846637/b4e1d93a-0b05-42a9-874e-0270b614b793)

[screen-capture (1).webm](https://github.com/Real-Dev-Squad/website-status/assets/41846637/abf43514-2cd6-44a2-8718-8de70c46b5e7)

### Follow-up Issues (if any)
No

### Test Stat
Before:
![image](https://github.com/Real-Dev-Squad/website-status/assets/41846637/d21d82b6-ce86-44db-a179-3937764d1e9f)

After:
![image](https://github.com/Real-Dev-Squad/website-status/assets/41846637/f6d00155-9a8c-4b2c-bc65-0bf5751302e6)

