### PR TITLE
Fix: Progress Indicator Color Overflow

### DIFF
--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -158,7 +158,7 @@ $progressTextAnimation: #9babb8;
 }
 
 .progressStyle {
-    height: 0.4rem;
+    height: 100%;
     border-radius: 1rem;
 }
 


### PR DESCRIPTION
Closes #877 

### Issue:
Progress Indicator Overflow

### Description:
Progress indicator color overflows content area of the indicator. Changing colored area's height relative to it's parent solves this issue.

### Dev Tested:
- [x] Yes

### Images of the change:
before:
![overflow](https://github.com/Real-Dev-Squad/website-status/assets/87164140/ff47eecd-a4ae-4eef-a170-e5382b3f653f)

after:
![overflow-fixed](https://github.com/Real-Dev-Squad/website-status/assets/87164140/9039225f-8740-4c23-aaaf-b75fe78956f2)

### Test Coverage
![Screenshot_test](https://github.com/Real-Dev-Squad/website-status/assets/87164140/4e13c517-291e-4387-9ca7-3da2bde7767f)
