### PR TITLE
Fix: Dynamic Title Hydration Problem

### DIFF
--- a/src/components/head/index.tsx
+++ b/src/components/head/index.tsx
@@ -7,7 +7,7 @@ type CustomHeadProps = {
 
 const CustomHead: FC<CustomHeadProps> = ({ title }) => (
     <Head>
-        <title>{title} | Status Real Dev Squad</title>
+        <title>{`${title} | Status Real Dev Squad`}</title>
         <link rel="shortcut icon" href="RDSLogo.png" type="image/x-icon" />
     </Head>
 );


### PR DESCRIPTION
closes #893 

### Issue:
Fix Dymnaic Title Hydration Problem

### Description:
This PR fixes the dynamic title hydration problem where the title was being rendered differently on the server and client. On each page reload, title change after initial loading is fixed. Also no warning in dev console regarding this issue.
This fix is achieved by using string interpolation for dynamic title, which creates only one text node inside title element.

### Dev Tested:
- [x] Yes

### Images/video of the change:

Title is properly rendered.
https://github.com/Real-Dev-Squad/website-status/assets/87164140/77d85473-4376-45c6-92be-c9b0891aa6a8

Related warning not present in dev console
![dev-console-fixed](https://github.com/Real-Dev-Squad/website-status/assets/87164140/65813826-9de6-4dfa-8f1f-9c73aef1e6eb)

### Test Coverage
![title-test-coverage](https://github.com/Real-Dev-Squad/website-status/assets/87164140/f2865af6-d856-469d-972f-e902142cd346)
