### PR TITLE
[Bug] Status Site - Task cards are breaking UI due to title text getting truncated without text wrap

### DIFF
--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -79,18 +79,29 @@ $progressTextAnimation: #9babb8;
     font-size: 1.6rem;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
     font-weight: 500;
     color: #041187;
     width: 65%;
 
     @media (max-width: 768px) {
         width: 100%;
-        white-space: normal;
     }
 
     @media (max-width: 288px) {
         width: 90%;
+    }
+}
+
+.cardTitleText {
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    white-space: pre-wrap;
+
+    @media (max-width: 368px) {
+        -webkit-line-clamp: 2;
     }
 }
 
@@ -400,12 +411,13 @@ $progressTextAnimation: #9babb8;
     width: 100%;
     display: flex;
     gap: 5px;
+    flex-wrap: wrap;
 
     @media (max-width: 448px) {
         align-items: baseline;
     }
 
-    @media (max-width: 288px) {
+    @media (max-width: 400px) {
         flex-direction: column;
         width: 90%;
     }

--- a/src/components/tasks/card/index.tsx
+++ b/src/components/tasks/card/index.tsx
@@ -520,7 +520,7 @@ const Card: FC<CardProps> = ({
                         taskId={cardDetails.id}
                     >
                         <span
-                            className={classNames.cardTitle}
+                            className={classNames.cardTitleText}
                             contentEditable={isEditable}
                             onKeyDown={(e) => handleChange(e, 'title')}
                             role="button"


### PR DESCRIPTION
### Issue: #928 

### Description:
- On [Tasks Page](https://status.realdevsquad.com/tasks?q=status%3Aall), when the title text doesn't fit in one line, the card title has white-space set to no-wrap causing the UI to break.

- PFB the screenshots
![image](https://github.com/Real-Dev-Squad/website-status/assets/75213145/fb0302c9-0f91-402c-bbd5-87c9fa6a7a47)
![image](https://github.com/Real-Dev-Squad/website-status/assets/75213145/5018a9f7-7b1b-4146-b5f5-909c4b90e7c8)

- With white-space set to normal prevents UI break as below:
![image](https://github.com/Real-Dev-Squad/website-status/assets/75213145/fada6723-cb83-4162-a44f-ef812c62c3f2)


### Anthing you would like to inform the reviewer about:
- CSS Fixes: When the title text doesn't fit, it gets truncated and instead of setting no-wrap to white-space we let the text wrap preserving spaces by setting white-space to pre-wrap

### Dev Tested:
- [✅] Yes
- ![test ss](https://github.com/Real-Dev-Squad/website-status/assets/75213145/220eb3e0-b4a9-408c-97a4-cd955fefdebc)



### Images/video of the change:
https://github.com/Real-Dev-Squad/website-status/assets/75213145/674aa82c-4495-4c3f-8b66-ffe45d02a644

### Follow-up Issues (if any)
NA
