### PR TITLE
add UTC time format on idle page

### DIFF
--- a/src/helperFunctions/getIdleSinceText.ts
+++ b/src/helperFunctions/getIdleSinceText.ts
@@ -5,11 +5,12 @@ import {
 
 const getIdleSinceText = (idleSince: string) => {
     const presentDate = new Date();
+    const idleSinceDate = new Date(idleSince);
     const differenceInDay = Math.round(
-        (presentDate.getTime() - parseInt(idleSince)) /
+        (presentDate.setUTCHours(0, 0, 0, 0) -
+            idleSinceDate.setUTCHours(0, 0, 0, 0)) /
             TOTAL_MILLISECONDS_IN_A_DAY
     );
-
     const differenceInHours = Math.abs(
         Math.round(
             (presentDate.getTime() - parseInt(idleSince)) /


### PR DESCRIPTION
### Issue: https://github.com/Real-Dev-Squad/website-status/issues/932

### Description:
- The idle page where we show idle users and their time/day for how long they have been idle. So to show time/day we are not using UTC time format.
- So i have added UTC time format there.

### Anthing you would like to inform the reviewer about:
- Didn't write any test cause it is not require and test are already written for card component.
 
### Dev Tested:
- [x] Yes


Image proof :-
![Idle Users _ Status Real Dev Squad _ Status Real Dev Squad - Google Chrome 14-10-2023 02_50_09](https://github.com/Real-Dev-Squad/website-status/assets/22213872/df97d638-7a3e-464b-9dce-ee3bc3d132b8)
