### PR TITLE
Fix Routes Naming

### DIFF
--- a/__tests__/Unit/Components/Header/Header.test.tsx
+++ b/__tests__/Unit/Components/Header/Header.test.tsx
@@ -239,6 +239,8 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeTruthy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -248,6 +250,8 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Issues category', () => {
@@ -266,6 +270,8 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeTruthy();
@@ -275,6 +281,8 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Mine category', () => {
@@ -293,6 +301,8 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -302,6 +312,8 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Open PRs category', () => {
@@ -320,6 +332,8 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -329,6 +343,8 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Stale PRs category', () => {
@@ -347,6 +363,8 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -356,6 +374,8 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Idle Users category', () => {
@@ -374,6 +394,8 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -383,6 +405,8 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeTruthy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Standup category', () => {
@@ -401,6 +425,8 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -410,6 +436,8 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeTruthy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Availability Panel category', () => {
@@ -428,6 +456,8 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -437,5 +467,69 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeTruthy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
+    });
+
+    it('should have Open PRs Dev category', () => {
+        useRouter.mockImplementation(() => {
+            return {
+                pathname: '/pull-requests',
+                query: { state: 'open', dev: true },
+            };
+        });
+        render(<Header />);
+        const taskElement = screen.getByText('Tasks');
+        const issueElement = screen.getByText('Issues');
+        const mineElement = screen.getByText('Mine');
+        const openPRElement = screen.getByText('Open PRs');
+        const stalePRElement = screen.getByText('Stale PRs');
+        const idleUsersElement = screen.getByText('Idle Users');
+        const standupElement = screen.getByText('Standup');
+        const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
+
+        expect(taskElement.classList.contains('active')).toBeFalsy();
+        expect(issueElement.classList.contains('active')).toBeFalsy();
+        expect(mineElement.classList.contains('active')).toBeFalsy();
+        expect(openPRElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRElement.classList.contains('active')).toBeFalsy();
+        expect(idleUsersElement.classList.contains('active')).toBeFalsy();
+        expect(standupElement.classList.contains('active')).toBeFalsy();
+        expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeTruthy();
+        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
+    });
+
+    it('should have Stale PRs Dev category', () => {
+        useRouter.mockImplementation(() => {
+            return {
+                pathname: '/pull-requests',
+                query: { state: 'stale', dev: true },
+            };
+        });
+        render(<Header />);
+        const taskElement = screen.getByText('Tasks');
+        const issueElement = screen.getByText('Issues');
+        const mineElement = screen.getByText('Mine');
+        const openPRElement = screen.getByText('Open PRs');
+        const stalePRElement = screen.getByText('Stale PRs');
+        const idleUsersElement = screen.getByText('Idle Users');
+        const standupElement = screen.getByText('Standup');
+        const availabilityElement = screen.getByText('Availability Panel');
+        const openPRDevElement = screen.getByText('Open PRs(dev)');
+        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
+
+        expect(taskElement.classList.contains('active')).toBeFalsy();
+        expect(issueElement.classList.contains('active')).toBeFalsy();
+        expect(mineElement.classList.contains('active')).toBeFalsy();
+        expect(openPRElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRElement.classList.contains('active')).toBeFalsy();
+        expect(idleUsersElement.classList.contains('active')).toBeFalsy();
+        expect(standupElement.classList.contains('active')).toBeFalsy();
+        expect(availabilityElement.classList.contains('active')).toBeFalsy();
+        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
+        expect(stalePRDevElement.classList.contains('active')).toBeTruthy();
     });
 });

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -26,6 +26,7 @@ export const Header = () => {
     // Dev feature toggle
     const { query } = router;
     const dev = !!query.dev;
+    const queryState = query.state;
 
     return (
         <div className={styles.header}>
@@ -40,12 +41,17 @@ export const Header = () => {
 
             {dev &&
                 devHeaderCategories.map(
-                    ({ title, refURL, pathName }, index) => (
+                    ({ title, refURL, pathName, state }, index) => (
                         <HeaderLink
                             key={index}
                             title={title}
                             link={refURL}
-                            isActive={router.pathname === pathName}
+                            isActive={
+                                router.pathname === pathName &&
+                                (router.pathname === '/pull-requests'
+                                    ? queryState === state
+                                    : true)
+                            }
                         />
                     )
                 )}

--- a/src/components/PullRequestList/index.tsx
+++ b/src/components/PullRequestList/index.tsx
@@ -134,8 +134,8 @@ const PullRequestList: FC<PullRequestListProps> = ({ prType }) => {
                         );
                     })}
                     {isLoading &&
-                        [...Array(15)].map((e: number) => (
-                            <CardShimmer key={e} />
+                        [...Array(15)].map((n: number, index) => (
+                            <CardShimmer key={index} />
                         ))}
                 </div>
             </div>

--- a/src/constants/header-categories.ts
+++ b/src/constants/header-categories.ts
@@ -42,4 +42,16 @@ export const devHeaderCategories = [
         refURL: '/availability-panel',
         pathName: '/availability-panel',
     },
+    {
+        title: 'Open PRs(dev)',
+        refURL: '/pull-requests?state=open&dev=true',
+        pathName: '/pull-requests',
+        state: 'open',
+    },
+    {
+        title: 'Stale PRs(dev)',
+        refURL: '/pull-requests?state=stale&dev=true',
+        pathName: '/pull-requests',
+        state: 'stale',
+    },
 ];

--- a/src/pages/pull-requests/index.tsx
+++ b/src/pages/pull-requests/index.tsx
@@ -1,0 +1,39 @@
+import { FC, useEffect } from 'react';
+import PullRequestList from '@/components/PullRequestList';
+import { useRouter } from 'next/router';
+import Layout from '@/components/Layout';
+
+const PullRequests: FC = () => {
+    const router = useRouter();
+    const { query } = router;
+
+    const state = query.state;
+
+    useEffect(() => {
+        if (!router.isReady) return;
+
+        if (!state || (state !== 'stale' && state !== 'open')) {
+            router.push('/pull-requests?state=open&dev=true');
+        }
+    }, [state, router]);
+
+    if (state && state === 'open') {
+        return <PullRequestList prType="open" />;
+    } else if (state && state === 'stale') {
+        // returning the component inside an extra div ensures proper
+        // re-initialization of states in PullRequestList component
+        return (
+            <div>
+                <PullRequestList prType="stale" />
+            </div>
+        );
+    } else {
+        return (
+            <Layout>
+                <>Loading...</>
+            </Layout>
+        );
+    }
+};
+
+export default PullRequests;


### PR DESCRIPTION
closes #924 

### **Issue:**
**Fix Routes Naming**
The naming of these routes doesn't follow conventions and should be updated following routes naming convention.

Open PRs: `https://status.realdevsquad.com/openPRs`
Stale PRs: `https://status.realdevsquad.com/stale-pr`

### **Description:**
The updated routes are now,
Open PRs: `https://status.realdevsquad.com/pull-requests?state=open`
Stale PRs: `https://status.realdevsquad.com/pull-requests?state=stale`

There was an issue in `PullRequestList` component (used in these routes) related to duplicate key, fixed this problem with unique key values.

### **Feature Flag**
The updated routes are available in Header links under dev=true feature flag.

### **Dev Tested:**
- [x] Yes
### Test Stats
**Before**

![test-stats-before](https://github.com/Real-Dev-Squad/website-status/assets/87164140/138822a7-c129-4879-a9c9-07c78b4978fe)

**After**

![test-stats-after](https://github.com/Real-Dev-Squad/website-status/assets/87164140/69d42ead-0efb-49f7-85cc-6b8dd7a9b340)


### **Images/video of the change:**

https://github.com/Real-Dev-Squad/website-status/assets/87164140/a584177d-9841-4d48-bcd3-02526b95c8f6



### **Follow-up Issues (if any)**
The updated routes are under feature flag and should be taken out of feature flag when appropriate and previous routes should be replaced when these routes comes out of feature flag.

Pull Requests routes (Open PRs and Stale PRs) components have room for improvements in terms of UI/UX. Will create new issues regarding this.