### PR TITLE
Issue 928 Followup: - Width of task cards isn't consistent  across different task-status tabs

### DIFF
--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -83,7 +83,7 @@ $progressTextAnimation: #9babb8;
     font-weight: 500;
     color: #041187;
     width: 65%;
-    word-break: break-all;
+    word-break: break-word;
 
     @media (max-width: 768px) {
         width: 100%;

--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -83,13 +83,10 @@ $progressTextAnimation: #9babb8;
     font-weight: 500;
     color: #041187;
     width: 65%;
+    word-break: break-all;
 
     @media (max-width: 768px) {
         width: 100%;
-    }
-
-    @media (max-width: 288px) {
-        width: 90%;
     }
 }
 
@@ -120,6 +117,7 @@ $progressTextAnimation: #9babb8;
     align-items: center;
     gap: 1rem;
     margin-top: 0.8rem;
+    flex-wrap: wrap;
 
     .card__top__button {
         margin-top: 0;

--- a/src/components/tasks/card/card.module.scss
+++ b/src/components/tasks/card/card.module.scss
@@ -82,7 +82,7 @@ $progressTextAnimation: #9babb8;
     white-space: normal;
     font-weight: 500;
     color: #041187;
-    width: 65%;
+    max-width: 30rem;
     word-break: break-word;
 
     @media (max-width: 768px) {


### PR DESCRIPTION
### Issue:
Followup on issue #928 

### Description:

1. Width of the task cards isn't consistent across all tabs
2. Incase of title with a longer word, word doesn't break and  wrap to next line in smaller mobile screens. Hence css fixes has been made in this PR

### Screenshots
#### 1. For inconsistent width:

Before:
- ![For inconsistent width](https://github.com/Real-Dev-Squad/website-status/assets/75213145/24c16fcd-2596-4ea2-888c-4492d5340a42)
- ![For inconsistent width](https://github.com/Real-Dev-Squad/website-status/assets/75213145/9c92a4bb-6564-4d2c-b5d2-61b83295747e)

After:
- For inconsistent width fix refer this [video here](https://github.com/Real-Dev-Squad/website-status/assets/75213145/2659ec3c-a78e-43c9-a583-20ef690db888)


#### 2. Incase of title with longer words, words doesn't break and  wrap to next line in smaller mobile screens. 
Before:
- ![For issue 2](https://github.com/Real-Dev-Squad/website-status/assets/75213145/eb71c14a-5010-4a11-a561-4cb0a734d228)

After:
- ![image](https://github.com/Real-Dev-Squad/website-status/assets/75213145/446e15d1-9c9a-4cfa-a8fb-797a5eb88cfd)


### Anthing you would like to inform the reviewer about:
- Title CSS has been updated to fix the above 2 issues and the page supports upto a min of 280px as in Galaxy Fold.

### Dev Tested:
- [x] Yes
- ![image](https://github.com/Real-Dev-Squad/website-status/assets/75213145/2f0b1c12-64ec-4fcc-9ad2-bbf9bd19666b)

### Images/video of the change:
https://github.com/Real-Dev-Squad/website-status/assets/75213145/5f2860fc-ed5a-4061-825f-a9aeedc77202

### Follow-up Issues (if any)
[Parent Issue](https://github.com/Real-Dev-Squad/website-status/issues/928)
