### PR TITLE
set the default ends on field with 2 days offset

### DIFF
--- a/__tests__/Unit/Components/Issues/ActionForm.test.tsx
+++ b/__tests__/Unit/Components/Issues/ActionForm.test.tsx
@@ -75,4 +75,22 @@ describe('Issues Action Form Component', () => {
         notFoundTextNode = screen.getByTestId('user_not_found');
         expect(notFoundTextNode).toBeInTheDocument();
     });
+
+    test('Sets the default ends On date to offset 2 days from today.', () => {
+        const screen = renderWithProviders(<ActionForm taskId="123" />);
+        const endsOn = screen.getByLabelText(/Ends on:/) as HTMLInputElement;
+
+        const today = new Date();
+        const calculatedDate = new Date(today);
+        calculatedDate.setDate(today.getDate() + 2);
+        const offsetDate = `${calculatedDate.getFullYear()}-${(
+            calculatedDate.getMonth() + 1
+        )
+            .toString()
+            .padStart(2, '0')}-${calculatedDate
+            .getDate()
+            .toString()
+            .padStart(2, '0')}`;
+        expect(endsOn.value).toBe(offsetDate);
+    });
 });

--- a/__tests__/Utils/time.test.ts
+++ b/__tests__/Utils/time.test.ts
@@ -1,5 +1,3 @@
-// Import the function to be tested
-
 import { getDateRelativeToToday } from '@/utils/time';
 
 describe('getDateRelativeToToday', () => {

--- a/__tests__/Utils/time.test.ts
+++ b/__tests__/Utils/time.test.ts
@@ -1,0 +1,35 @@
+// Import the function to be tested
+
+import { getDateRelativeToToday } from '@/utils/time';
+
+describe('getDateRelativeToToday', () => {
+    it('should return a timestamp for "timestamp" format', () => {
+        const daysFromToday = 2;
+        const format = 'timestamp';
+        const result = getDateRelativeToToday(daysFromToday, format);
+
+        expect(typeof result).toBe('number');
+    });
+
+    it('should return a formatted date for "formattedDate" format', () => {
+        const daysFromToday = 2;
+        const format = 'formattedDate';
+        const result = getDateRelativeToToday(daysFromToday, format) as string;
+
+        expect(typeof result).toBe('string');
+
+        const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+        expect(dateRegex.test(result)).toBe(true);
+    });
+
+    it('should throw an error for an invalid format', () => {
+        const daysFromToday = 2;
+        const format = 'invalidFormat';
+
+        expect(() => {
+            getDateRelativeToToday(daysFromToday, format);
+        }).toThrow(
+            'Invalid format parameter. Use "timestamp" or "formattedDate".'
+        );
+    });
+});

--- a/src/components/issues/ActionForm.tsx
+++ b/src/components/issues/ActionForm.tsx
@@ -14,6 +14,7 @@ import { useGetAllUsersByUsernameQuery } from '@/app/services/usersApi';
 import { GithubInfo } from '@/interfaces/suggestionBox.type';
 import { userDataType } from '@/interfaces/user.type';
 import { DUMMY_PROFILE } from '@/constants/display-sections';
+import { getDateRelativeToToday } from '@/utils/time';
 
 type ActionFormReducer = {
     assignee: string;
@@ -26,10 +27,10 @@ type ActionFormProps = {
 };
 
 const taskStatus = Object.entries(BACKEND_TASK_STATUS);
-
+const endTimeStamp: number = getDateRelativeToToday(2, 'timestamp') as number;
 const initialState = {
     assignee: '',
-    endsOn: Date.now() / 1000,
+    endsOn: endTimeStamp,
     status: 'ASSIGNED',
 };
 
@@ -52,6 +53,9 @@ const reducer = (state: ActionFormReducer, action: reducerAction) => {
 const { SUCCESS, ERROR } = ToastTypes;
 
 const ActionForm: FC<ActionFormProps> = ({ taskId }) => {
+    const [endsOnDate, setEndsOnDate] = useState(
+        getDateRelativeToToday(2, 'formattedDate')
+    );
     const [state, dispatch] = useReducer(reducer, initialState);
     const [isAssigned, setIsAssigned] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
@@ -150,9 +154,11 @@ const ActionForm: FC<ActionFormProps> = ({ taskId }) => {
                         id="ends-on"
                         className={styles.assign}
                         type="date"
-                        onChange={(e) =>
-                            dispatch({ type: 'endsOn', value: e.target.value })
-                        }
+                        value={endsOnDate}
+                        onChange={(e) => {
+                            setEndsOnDate(e.target.value);
+                            dispatch({ type: 'endsOn', value: e.target.value });
+                        }}
                     />
                     <label htmlFor="status" className={styles.assign_label}>
                         Status:

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,26 @@
+export const getDateRelativeToToday = (
+    daysFromToday: number,
+    format: 'timestamp' | 'formattedDate'
+): number | string => {
+    const today = new Date();
+    const calculatedDate = new Date(today);
+    calculatedDate.setDate(today.getDate() + daysFromToday);
+
+    if (format === 'timestamp') {
+        return calculatedDate.getTime() / 1000;
+    } else if (format === 'formattedDate') {
+        // Converting the date to a string in the "yyyy-mm-dd" format
+        return `${calculatedDate.getFullYear()}-${(
+            calculatedDate.getMonth() + 1
+        )
+            .toString()
+            .padStart(2, '0')}-${calculatedDate
+            .getDate()
+            .toString()
+            .padStart(2, '0')}`;
+    } else {
+        throw new Error(
+            'Invalid format parameter. Use "timestamp" or "formattedDate".'
+        );
+    }
+};


### PR DESCRIPTION
### Issue:
- #902

### Description:
When creating a task from an issue and assigning it to someone, it's important to establish a reasonable timeframe for task completion. To streamline this process and ensure clarity, we added a default "Ends On" date for task assignments i.e 2 days from the current day.

### Anthing you would like to inform the reviewer about:
No

### Dev Tested:
- [x] Yes

### Images/video of the change:
today date is 20/10/2023

![image](https://github.com/Real-Dev-Squad/website-status/assets/97341921/52512fbf-2136-4326-89b9-67d42446b45d)

### Coverage: 

![image](https://github.com/Real-Dev-Squad/website-status/assets/97341921/7759516a-c513-47ea-85ec-697511bbfe06)

![image](https://github.com/Real-Dev-Squad/website-status/assets/97341921/3e008aab-c645-4937-988e-55a7139125ea)


### Follow-up Issues (if any)
None