### PR TITLE
Fixes wrong initial value of ends on date in task request form

### DIFF
--- a/src/components/issues/Card.tsx
+++ b/src/components/issues/Card.tsx
@@ -105,8 +105,9 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
             requestType: TASK_REQUEST_TYPES.CREATION,
             proposedStartDate: data.startedOn,
             proposedDeadline: data.endsOn,
-            description: data.description || ' ',
+            description: data.description,
         };
+        if (!requestData.description) delete requestData.description;
         try {
             const url = TASK_REQUEST_URL;
             const { requestPromise } = fetch({

--- a/src/components/issues/TaskRequestForm.tsx
+++ b/src/components/issues/TaskRequestForm.tsx
@@ -2,6 +2,7 @@ import { FC, MouseEvent, useReducer, useState } from 'react';
 import styles from '@/components/issues/Card.module.scss';
 import { reducerAction } from '@/types/ProgressUpdates';
 import { Loader } from '../tasks/card/Loader';
+import { getDateRelativeToToday } from '@/utils/time';
 
 type ActionFormReducer = {
     startedOn: number | string;
@@ -15,15 +16,10 @@ type ActionFormProps = {
     createTaskRequest: (data: ActionFormReducer) => Promise<void>;
 };
 
-const date = new Date();
-const today = date.toISOString().split('T')[0];
-date.setDate(date.getDate() + 7);
-const sevenDaysFromToday = date.toISOString().split('T')[0];
-
 const initialState = {
-    endsOn: Date.now(),
-    startedOn: Date.now(),
-    description: ' ',
+    endsOn: (getDateRelativeToToday(7, 'timestamp') as number) * 1000,
+    startedOn: (getDateRelativeToToday(0, 'timestamp') as number) * 1000,
+    description: undefined,
 };
 
 const reducer = (state: ActionFormReducer, action: reducerAction) => {
@@ -76,7 +72,10 @@ const TaskRequestForm: FC<ActionFormProps> = ({
                         className={`${styles.assign} ${styles.input_date}`}
                         type="date"
                         required
-                        defaultValue={today}
+                        defaultValue={getDateRelativeToToday(
+                            0,
+                            'formattedDate'
+                        )}
                         onChange={(e) =>
                             dispatch({
                                 type: 'startedOn',
@@ -94,7 +93,10 @@ const TaskRequestForm: FC<ActionFormProps> = ({
                         id="ends-on"
                         className={` ${styles.assign} ${styles.input_date}`}
                         type="date"
-                        defaultValue={sevenDaysFromToday}
+                        defaultValue={getDateRelativeToToday(
+                            7,
+                            'formattedDate'
+                        )}
                         required
                         onChange={(e) =>
                             dispatch({ type: 'endsOn', value: e.target.value })

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -5,7 +5,7 @@ export const getDateRelativeToToday = (
     const today = new Date();
     const calculatedDate = new Date(today);
     calculatedDate.setDate(today.getDate() + daysFromToday);
-
+    calculatedDate.setHours(5, 30, 0, 0);
     if (format === 'timestamp') {
         return calculatedDate.getTime() / 1000;
     } else if (format === 'formattedDate') {


### PR DESCRIPTION


Developer Name: @Ajeyakrishna-k 

### Issue Ticket Number:-
- #911 

### Description:
- Previously end date had today's date as default value. This PR sets the default value of end date seven days from today.
- Removes description field if falsy.

### Anthing you would like to inform the reviewer about:

### Dev Tested:
- [x] Yes

Backend changes
- [ ] Yes


Frontend Changes
- [x] Yes

Is Under Feature Flag 
- [x] Yes

Database changes
- [ ] Yes


### Images/video of the change:
Test coverage:
![Screenshot 2023-10-24 at 9 26 09 AM](https://github.com/Real-Dev-Squad/website-status/assets/98796547/e2a9c281-09f6-4fe3-9059-bd79a26304d7)

Screenshot: 
<img width="1122" alt="Screenshot 2023-10-24 at 9 46 42 AM" src="https://github.com/Real-Dev-Squad/website-status/assets/98796547/af0904c5-b346-44d6-b9c4-6b1b4f93dd33">

### Follow-up Issues (if any)
