### PR TITLE
Fix APIs Being Called Before Input Is Provided

### DIFF
--- a/__tests__/Unit/pages/issues/Issues.test.tsx
+++ b/__tests__/Unit/pages/issues/Issues.test.tsx
@@ -23,7 +23,7 @@ describe('Issues Page', () => {
     const loadingText = 'Loading...';
 
     it('Should render search fields in issues page properly', async () => {
-        const { getByPlaceholderText, getByRole, getByText } = renderWithRouter(
+        const { getByPlaceholderText, getByRole } = renderWithRouter(
             <Provider store={store()}>
                 <Issues />
             </Provider>
@@ -35,9 +35,7 @@ describe('Issues Page', () => {
         const buttonElement = getByRole('button', buttonAttribute);
         expect(buttonElement).toBeInTheDocument();
 
-        // button should be disabled when the data is loading
-        const loadingElement = getByText(loadingText);
-        expect(loadingElement).toBeInTheDocument();
+        // button should be disabled with no input provided
         expect(buttonElement).toBeDisabled();
     });
 
@@ -48,14 +46,6 @@ describe('Issues Page', () => {
                     <Issues />
                 </Provider>
             );
-
-        // Test for issues title when API called without search query param
-        const issueTitleBeforeQuerySearch =
-            'Status view to all features being built for our app';
-        const issueTitleBeforeQuerySearchElement = await findByText(
-            issueTitleBeforeQuerySearch
-        );
-        expect(issueTitleBeforeQuerySearchElement).toBeInTheDocument();
 
         // trigger change and click event to search issues with query param
         const inputElement = await findByPlaceholderText(inputPlaceholderText);

--- a/src/components/issues/ActionForm.tsx
+++ b/src/components/issues/ActionForm.tsx
@@ -74,9 +74,12 @@ const ActionForm: FC<ActionFormProps> = ({
         getDateRelativeToToday(2, 'formattedDate')
     );
     const [showSuggestion, setShowSuggestion] = useState(false);
-    const { data: userData } = useGetAllUsersByUsernameQuery({
-        searchString: state.assignee,
-    });
+    const { data: userData } = useGetAllUsersByUsernameQuery(
+        {
+            searchString: state.assignee,
+        },
+        { skip: !state.assignee }
+    );
 
     useEffect(() => {
         setIsLoading(loading);

--- a/src/pages/issues/index.tsx
+++ b/src/pages/issues/index.tsx
@@ -82,10 +82,6 @@ const Issues: FC = () => {
         }
     };
 
-    useEffect(() => {
-        fetchIssues();
-    }, []);
-
     let renderElement = <p>Loading...</p>;
 
     if (!isLoading) {


### PR DESCRIPTION
Closes #891 
### Issue:
- #891 
### Description:
On Issues page api call for issues and assignee are being done before any input is provided. During assignee suggestion for task assignment api calls are being made even when assignee input is empty.

### Feature Flag:
This is a fix change that affects both features under feature flag and out of feature flag.

### Frontend Changes
- [x] Yes
- [ ] No

### Backend Changes
- [ ] Yes
- [x] No

### Dev Tested:
- [x] Yes
- [ ] No

![Screenshot_test](https://github.com/Real-Dev-Squad/website-status/assets/87164140/6ac994d9-6258-4de0-8183-fd6d451f84b3)


### Images/video of the change:
Before:
![Screenshot_before](https://github.com/Real-Dev-Squad/website-status/assets/87164140/40b24c8a-acbb-4c3d-b789-5e9021251d4b)

After:
![Screenshot_after](https://github.com/Real-Dev-Squad/website-status/assets/87164140/92e71d8b-aaca-4eea-a2d7-f4625edfd559)

https://github.com/Real-Dev-Squad/website-status/assets/87164140/2e2ba175-e54d-423f-a189-f0eb12113973


