### PR TITLE
super_user only change status done under feature flag

### DIFF
--- a/__tests__/Unit/Components/Tasks/TaskStatusEditMode.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskStatusEditMode.test.tsx
@@ -115,6 +115,33 @@ describe('TaskStatusEditMode', () => {
         expect(allOptions).toEqual(allTaskStatus);
     });
 
+    it('renders a list of task under feature flag', () => {
+        const mockUpdateTask = jest.fn();
+        const setEditedTaskDetails = jest.fn();
+
+        renderWithRouter(
+            <Provider store={store()}>
+                <TaskStatusEditMode
+                    task={BLOCKED_TASK}
+                    setEditedTaskDetails={setEditedTaskDetails}
+                    isDevMode={true}
+                />
+            </Provider>
+        );
+
+        const statusSelect = screen.getByLabelText('Status:');
+
+        const allOptions = Array.from(
+            statusSelect.querySelectorAll('option')
+        ).map((option) => [option.value, option.textContent]);
+
+        const allTaskStatus = Object.entries(BACKEND_TASK_STATUS)
+            .map(([name, status]) => [status, beautifyStatus(name)])
+            .filter(([status]) => status !== BACKEND_TASK_STATUS.COMPLETED);
+
+        expect(allOptions).toEqual(allTaskStatus);
+    });
+
     it('renders the spinner and error icon when the task update fails', async () => {
         const setEditedTaskDetails = jest.fn();
 

--- a/src/components/tasks/card/TaskStatusEditMode.tsx
+++ b/src/components/tasks/card/TaskStatusEditMode.tsx
@@ -5,21 +5,23 @@ import classNames from '@/components/tasks/card/card.module.scss';
 import { PENDING, SAVED, ERROR_STATUS } from '../constants';
 import { useUpdateTaskMutation } from '@/app/services/tasksApi';
 import { StatusIndicator } from './StatusIndicator';
-import { useRouter } from 'next/router';
 
 type Props = {
     task: task;
     setEditedTaskDetails: React.Dispatch<React.SetStateAction<CardTaskDetails>>;
+    isDevMode: boolean;
 };
 
 // TODO: remove this after fixing the card beautify status
 const beautifyStatus = (status: string) => status.split('_').join(' ');
 
-const TaskStatusEditMode = ({ task, setEditedTaskDetails }: Props) => {
-    const router = useRouter();
-    const devMode = router.query.dev === 'true' ? true : false;
+const TaskStatusEditMode = ({
+    task,
+    setEditedTaskDetails,
+    isDevMode,
+}: Props) => {
     const taskStatus = Object.entries(BACKEND_TASK_STATUS).filter(
-        ([key]) => !(devMode === true && key === 'COMPLETED')
+        ([key]) => !(isDevMode && key === 'COMPLETED')
     );
     const [saveStatus, setSaveStatus] = useState('');
     const [updateTask] = useUpdateTaskMutation();

--- a/src/components/tasks/card/TaskStatusEditMode.tsx
+++ b/src/components/tasks/card/TaskStatusEditMode.tsx
@@ -5,6 +5,7 @@ import classNames from '@/components/tasks/card/card.module.scss';
 import { PENDING, SAVED, ERROR_STATUS } from '../constants';
 import { useUpdateTaskMutation } from '@/app/services/tasksApi';
 import { StatusIndicator } from './StatusIndicator';
+import { useRouter } from 'next/router';
 
 type Props = {
     task: task;
@@ -13,9 +14,13 @@ type Props = {
 
 // TODO: remove this after fixing the card beautify status
 const beautifyStatus = (status: string) => status.split('_').join(' ');
-const taskStatus = Object.entries(BACKEND_TASK_STATUS);
 
 const TaskStatusEditMode = ({ task, setEditedTaskDetails }: Props) => {
+    const router = useRouter();
+    const devMode = router.query.dev === 'true' ? true : false;
+    const taskStatus = Object.entries(BACKEND_TASK_STATUS).filter(
+        ([key]) => !(devMode === true && key === 'COMPLETED')
+    );
     const [saveStatus, setSaveStatus] = useState('');
     const [updateTask] = useUpdateTaskMutation();
 

--- a/src/components/tasks/card/index.tsx
+++ b/src/components/tasks/card/index.tsx
@@ -33,12 +33,15 @@ import ProgressContainer from './progressContainer';
 import { PENDING, SAVED, ERROR_STATUS } from '../constants';
 import { StatusIndicator } from './StatusIndicator';
 import Suggestions from '../SuggestionBox/Suggestions';
+import { useRouter } from 'next/router';
 
 const Card: FC<CardProps> = ({
     content,
     shouldEdit = false,
     onContentChange = () => undefined,
 }) => {
+    const router = useRouter();
+    const isDevMode = router.query.dev === 'true' ? true : false;
     const statusRedList = [TASK_STATUS.BLOCKED];
     const statusNotOverDueList = [
         TASK_STATUS.COMPLETED,
@@ -568,6 +571,7 @@ const Card: FC<CardProps> = ({
                         <TaskStatusEditMode
                             task={editedTaskDetails}
                             setEditedTaskDetails={setEditedTaskDetails}
+                            isDevMode={isDevMode}
                         />
                     ) : (
                         <div className={classNames.statusContainer} style={{}}>


### PR DESCRIPTION
### Issue: https://github.com/Real-Dev-Squad/todo-action-items/issues/193

**Design Doc** https://docs.google.com/document/d/1C3oizE01vH6cQHRtoJbA7-QHDoDhHuPiMllqvh6v5cM/edit?usp=sharing

### Description:

- When super_user wants to change the status of a task card from "status-site," then they get only one option i.e. “DONE” under the feature flag.


### Dev Tested:
- [X] Yes

### Test Stats:

<img width="782" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/107163260/f3fcab31-f34b-426f-8425-268fbd8dd86a">

<img width="791" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/107163260/f1e16e86-834e-4433-a3b8-484dfceba6a0">

### Images/video of the change:

https://github.com/Real-Dev-Squad/website-status/assets/107163260/4d0ec009-7906-47e1-a8b2-82c2907be09b


