### PR TITLE
Remove Feature Flag - Super User Sees "DONE" Task Status and Excludes "COMPLETED" Task Status in Task Card Edit Mode

### DIFF
--- a/__tests__/Unit/Components/Tasks/TaskStatusEditMode.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskStatusEditMode.test.tsx
@@ -34,6 +34,7 @@ describe('TaskStatusEditMode', () => {
                 <TaskStatusEditMode
                     task={BLOCKED_TASK}
                     setEditedTaskDetails={setEditedTaskDetails}
+                    isDevMode={false}
                 />
             </Provider>
         );
@@ -53,6 +54,7 @@ describe('TaskStatusEditMode', () => {
                 <TaskStatusEditMode
                     task={BLOCKED_TASK}
                     setEditedTaskDetails={setEditedTaskDetails}
+                    isDevMode={false}
                 />
             </Provider>
         );
@@ -80,6 +82,7 @@ describe('TaskStatusEditMode', () => {
                 <TaskStatusEditMode
                     task={UN_ASSIGNED_TASK}
                     setEditedTaskDetails={setEditedTaskDetails}
+                    isDevMode={false}
                 />
             </Provider>
         );
@@ -89,7 +92,7 @@ describe('TaskStatusEditMode', () => {
         expect(statusSelect).toHaveValue('AVAILABLE');
     });
 
-    it('renders a list of task ', () => {
+    it('renders a list of task', () => {
         const mockUpdateTask = jest.fn();
         const setEditedTaskDetails = jest.fn();
 
@@ -98,33 +101,7 @@ describe('TaskStatusEditMode', () => {
                 <TaskStatusEditMode
                     task={BLOCKED_TASK}
                     setEditedTaskDetails={setEditedTaskDetails}
-                />
-            </Provider>
-        );
-
-        const statusSelect = screen.getByLabelText('Status:');
-
-        const allOptions = Array.from(
-            statusSelect.querySelectorAll('option')
-        ).map((option) => [option.value, option.textContent]);
-
-        const allTaskStatus = Object.entries(BACKEND_TASK_STATUS).map(
-            ([name, status]) => [status, beautifyStatus(name)]
-        );
-
-        expect(allOptions).toEqual(allTaskStatus);
-    });
-
-    it('renders a list of task under feature flag', () => {
-        const mockUpdateTask = jest.fn();
-        const setEditedTaskDetails = jest.fn();
-
-        renderWithRouter(
-            <Provider store={store()}>
-                <TaskStatusEditMode
-                    task={BLOCKED_TASK}
-                    setEditedTaskDetails={setEditedTaskDetails}
-                    isDevMode={true}
+                    isDevMode={false}
                 />
             </Provider>
         );
@@ -150,6 +127,7 @@ describe('TaskStatusEditMode', () => {
                 <TaskStatusEditMode
                     task={BLOCKED_TASK}
                     setEditedTaskDetails={setEditedTaskDetails}
+                    isDevMode={false}
                 />
             </Provider>,
             {}

--- a/src/components/tasks/card/TaskStatusEditMode.tsx
+++ b/src/components/tasks/card/TaskStatusEditMode.tsx
@@ -21,7 +21,7 @@ const TaskStatusEditMode = ({
     isDevMode,
 }: Props) => {
     const taskStatus = Object.entries(BACKEND_TASK_STATUS).filter(
-        ([key]) => !(isDevMode && key === 'COMPLETED')
+        ([key]) => !(key === 'COMPLETED')
     );
     const [saveStatus, setSaveStatus] = useState('');
     const [updateTask] = useUpdateTaskMutation();


### PR DESCRIPTION
### Issue: https://github.com/Real-Dev-Squad/website-status/issues/1014

### Description:

-  Remove "COMPLETED" task status from task card under edit mode
- Remove feature flag i.e. now super users to see "DONE" task status only and not "COMPLETED" task status in task card under edit mode
- Under feature flag changes pr which merged before: https://github.com/Real-Dev-Squad/website-status/pull/991


Is Under Feature Flag 
- [ ] Yes
- [X] No

Database changes
- [ ] Yes
- [X] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No


### Images/video of the change:

**Before Changes**

https://github.com/Real-Dev-Squad/website-status/assets/107163260/4329ded2-4aff-47a7-98fe-533c432e09b8

**After Change video:**

https://github.com/Real-Dev-Squad/website-status/assets/107163260/2e074569-6548-408e-aa1f-9902cd570857

**Test stats:**

<img width="712" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/107163260/c8e3f0d1-47d6-4b43-b250-854e931702a6">
