### PR TITLE
Removed default status from Task Search

### DIFF
--- a/__tests__/Unit/Components/Tasks/TaskSearch.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskSearch.test.tsx
@@ -166,7 +166,7 @@ describe('TaskSearch', () => {
         expect(onClickSearchButton).toBeCalled();
     });
 
-    test('Blocked Button Selected then Search Bar Display status:blocked', () => {
+    test('Blocked Button Selected then Search Bar Display status:blocked in dev', () => {
         const onSelect = jest.fn();
         const onInputChange = jest.fn();
         const onClickSearchButton = jest.fn();
@@ -183,9 +183,53 @@ describe('TaskSearch', () => {
 
         const filterButton = screen.getByText('Filter');
         fireEvent.click(filterButton);
-        const blockedButton = screen.getByText(/blocked/i);
+        const blockedButton = screen.getByRole('button', { name: /blocked/i });
         fireEvent.click(blockedButton);
         expect(onSelect).toHaveBeenCalledWith('BLOCKED');
         expect(screen.getByDisplayValue('status:blocked')).toBeInTheDocument();
+    });
+    test('Should not display status:all in search bar in dev mode', () => {
+        const onSelect = jest.fn();
+        const onInputChange = jest.fn();
+        const onClickSearchButton = jest.fn();
+
+        render(
+            <TaskSearch
+                dev={true}
+                onSelect={onSelect}
+                inputValue=""
+                onInputChange={onInputChange}
+                onClickSearchButton={onClickSearchButton}
+            />
+        );
+
+        const filterButton = screen.getByText('Filter');
+        fireEvent.click(filterButton);
+        const blockedButton = screen.getByRole('button', { name: /all/i });
+        fireEvent.click(blockedButton);
+        expect(onSelect).toHaveBeenCalledWith('ALL');
+        expect(screen.queryByText('status:all')).not.toBeInTheDocument();
+    });
+    test('Should display status:all in search bar', () => {
+        const onSelect = jest.fn();
+        const onInputChange = jest.fn();
+        const onClickSearchButton = jest.fn();
+
+        render(
+            <TaskSearch
+                dev={false}
+                onSelect={onSelect}
+                inputValue="status:all"
+                onInputChange={onInputChange}
+                onClickSearchButton={onClickSearchButton}
+            />
+        );
+
+        const filterButton = screen.getByText('Filter');
+        fireEvent.click(filterButton);
+        const blockedButton = screen.getByRole('button', { name: /all/i });
+        fireEvent.click(blockedButton);
+        expect(onSelect).toHaveBeenCalledWith('ALL');
+        expect(screen.getByDisplayValue('status:all')).toBeInTheDocument();
     });
 });

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -88,13 +88,20 @@ export const TasksContent = ({ dev }: { dev?: boolean }) => {
     };
 
     useEffect(() => {
-        setInputValue(
-            `${getQueryParamTab(selectedTab)} ${
+        let possibleInputValue = '';
+        if ((dev && selectedTab !== Tab.ALL) || !dev) {
+            possibleInputValue += `${getQueryParamTab(selectedTab)} `;
+        }
+        if (queryAssignees) {
+            possibleInputValue += `${getRouterQueryParamAssignee(
                 queryAssignees
-                    ? getRouterQueryParamAssignee(queryAssignees)
-                    : ''
-            } ${queryTitle ? getQueryParamTitle(queryTitle) : ''}`
-        );
+            )}`;
+        }
+        if (queryTitle) {
+            possibleInputValue += `${getQueryParamTitle(queryTitle)}`;
+        }
+
+        setInputValue(possibleInputValue.trim());
     }, [selectedTab]);
 
     useEffect(() => {

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -89,16 +89,16 @@ export const TasksContent = ({ dev }: { dev?: boolean }) => {
 
     useEffect(() => {
         let possibleInputValue = '';
-        if ((dev && selectedTab !== Tab.ALL) || !dev) {
+        if (!dev || selectedTab !== Tab.ALL) {
             possibleInputValue += `${getQueryParamTab(selectedTab)} `;
         }
         if (queryAssignees) {
             possibleInputValue += `${getRouterQueryParamAssignee(
                 queryAssignees
-            )}`;
+            )} `;
         }
         if (queryTitle) {
-            possibleInputValue += `${getQueryParamTitle(queryTitle)}`;
+            possibleInputValue += `${getQueryParamTitle(queryTitle)} `;
         }
 
         setInputValue(possibleInputValue.trim());


### PR DESCRIPTION
### Issue: [996](https://github.com/Real-Dev-Squad/website-status/issues/996)

### Description:
1. Task search should not show `status:all` in dev mode, as it won't make sense once we have suggestions.

### Anything you would like to inform the reviewer about:
NA

### Dev Tested:
- [x] Yes

### Under Feature Flag:
- [x] Yes

### Frontend Changes:
- [x] Yes

### Images/video of the change:

https://github.com/Real-Dev-Squad/website-status/assets/56365512/945beb60-7097-4820-a98b-87054437ab4a

### Test Suits
![image](https://github.com/Real-Dev-Squad/website-status/assets/56365512/6ff4b10d-4c0f-46d5-bff3-5526f2f3370a)

### Test Coverage
![image](https://github.com/Real-Dev-Squad/website-status/assets/56365512/d24d1064-5051-40f6-be2f-c2d3ed175471)

