### PR TITLE
Fixed displacement of profile dropdown in mobile mode

### DIFF
--- a/src/components/navBar/navBar.module.scss
+++ b/src/components/navBar/navBar.module.scss
@@ -171,7 +171,7 @@ $theme-active: #87d870;
 
     .userProfile {
         position: absolute;
-        top: 11%;
+        top: 0.55rem;
         right: 0%;
     }
 


### PR DESCRIPTION
### Issue:https://github.com/Real-Dev-Squad/website-status/issues/1019

### Description:
On opening nav dropdown in mobile mode the top right corner profile or github moved a little.

### Anthing you would like to inform the reviewer about:

### Dev Tested:
-  Yes


### Images/video of the change:
![image](https://github.com/Real-Dev-Squad/website-status/assets/68867418/8ae71dc8-6fc2-41a2-88c7-4e9254c5d281)


### Follow-up Issues (if any)
