### PR TITLE
Replace PR Routes with Updated Routes and Remove Feature Flag

### DIFF
--- a/__tests__/Unit/Components/Header/Header.test.tsx
+++ b/__tests__/Unit/Components/Header/Header.test.tsx
@@ -89,8 +89,8 @@ describe('Header without dev mode', () => {
     it('should have Open PRs category', () => {
         useRouter.mockImplementation(() => {
             return {
-                pathname: '/openPRs',
-                query: {},
+                pathname: '/pull-requests',
+                query: { state: 'open' },
             };
         });
         render(<Header />);
@@ -116,8 +116,8 @@ describe('Header without dev mode', () => {
     it('should have Stale PRs category', () => {
         useRouter.mockImplementation(() => {
             return {
-                pathname: '/stale-pr',
-                query: {},
+                pathname: '/pull-requests',
+                query: { state: 'stale' },
             };
         });
         render(<Header />);
@@ -239,8 +239,6 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeTruthy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -250,8 +248,6 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Issues category', () => {
@@ -270,8 +266,6 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeTruthy();
@@ -281,8 +275,6 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Mine category', () => {
@@ -301,8 +293,6 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -312,15 +302,13 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Open PRs category', () => {
         useRouter.mockImplementation(() => {
             return {
-                pathname: '/openPRs',
-                query: { dev: true },
+                pathname: '/pull-requests',
+                query: { state: 'open', dev: true },
             };
         });
         render(<Header />);
@@ -332,8 +320,6 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -343,15 +329,13 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Stale PRs category', () => {
         useRouter.mockImplementation(() => {
             return {
-                pathname: '/stale-pr',
-                query: { dev: true },
+                pathname: '/pull-requests',
+                query: { state: 'stale', dev: true },
             };
         });
         render(<Header />);
@@ -363,8 +347,6 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -374,8 +356,6 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Idle Users category', () => {
@@ -394,8 +374,6 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -405,8 +383,6 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeTruthy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Standup category', () => {
@@ -425,8 +401,6 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -436,8 +410,6 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeTruthy();
         expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
     });
 
     it('should have Availability Panel category', () => {
@@ -456,8 +428,6 @@ describe('Header with dev mode', () => {
         const idleUsersElement = screen.getByText('Idle Users');
         const standupElement = screen.getByText('Standup');
         const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
 
         expect(taskElement.classList.contains('active')).toBeFalsy();
         expect(issueElement.classList.contains('active')).toBeFalsy();
@@ -467,69 +437,5 @@ describe('Header with dev mode', () => {
         expect(idleUsersElement.classList.contains('active')).toBeFalsy();
         expect(standupElement.classList.contains('active')).toBeFalsy();
         expect(availabilityElement.classList.contains('active')).toBeTruthy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
-    });
-
-    it('should have Open PRs Dev category', () => {
-        useRouter.mockImplementation(() => {
-            return {
-                pathname: '/pull-requests',
-                query: { state: 'open', dev: true },
-            };
-        });
-        render(<Header />);
-        const taskElement = screen.getByText('Tasks');
-        const issueElement = screen.getByText('Issues');
-        const mineElement = screen.getByText('Mine');
-        const openPRElement = screen.getByText('Open PRs');
-        const stalePRElement = screen.getByText('Stale PRs');
-        const idleUsersElement = screen.getByText('Idle Users');
-        const standupElement = screen.getByText('Standup');
-        const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
-
-        expect(taskElement.classList.contains('active')).toBeFalsy();
-        expect(issueElement.classList.contains('active')).toBeFalsy();
-        expect(mineElement.classList.contains('active')).toBeFalsy();
-        expect(openPRElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRElement.classList.contains('active')).toBeFalsy();
-        expect(idleUsersElement.classList.contains('active')).toBeFalsy();
-        expect(standupElement.classList.contains('active')).toBeFalsy();
-        expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeTruthy();
-        expect(stalePRDevElement.classList.contains('active')).toBeFalsy();
-    });
-
-    it('should have Stale PRs Dev category', () => {
-        useRouter.mockImplementation(() => {
-            return {
-                pathname: '/pull-requests',
-                query: { state: 'stale', dev: true },
-            };
-        });
-        render(<Header />);
-        const taskElement = screen.getByText('Tasks');
-        const issueElement = screen.getByText('Issues');
-        const mineElement = screen.getByText('Mine');
-        const openPRElement = screen.getByText('Open PRs');
-        const stalePRElement = screen.getByText('Stale PRs');
-        const idleUsersElement = screen.getByText('Idle Users');
-        const standupElement = screen.getByText('Standup');
-        const availabilityElement = screen.getByText('Availability Panel');
-        const openPRDevElement = screen.getByText('Open PRs(dev)');
-        const stalePRDevElement = screen.getByText('Stale PRs(dev)');
-
-        expect(taskElement.classList.contains('active')).toBeFalsy();
-        expect(issueElement.classList.contains('active')).toBeFalsy();
-        expect(mineElement.classList.contains('active')).toBeFalsy();
-        expect(openPRElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRElement.classList.contains('active')).toBeFalsy();
-        expect(idleUsersElement.classList.contains('active')).toBeFalsy();
-        expect(standupElement.classList.contains('active')).toBeFalsy();
-        expect(availabilityElement.classList.contains('active')).toBeFalsy();
-        expect(openPRDevElement.classList.contains('active')).toBeFalsy();
-        expect(stalePRDevElement.classList.contains('active')).toBeTruthy();
     });
 });

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -30,28 +30,30 @@ export const Header = () => {
 
     return (
         <div className={styles.header}>
-            {headerCategories.map(({ title, refURL, pathName }, index) => (
-                <HeaderLink
-                    key={index}
-                    title={title}
-                    link={refURL}
-                    isActive={router.pathname === pathName}
-                />
-            ))}
+            {headerCategories.map(
+                ({ title, refURL, pathName, state }, index) => (
+                    <HeaderLink
+                        key={index}
+                        title={title}
+                        link={refURL}
+                        isActive={
+                            router.pathname === pathName &&
+                            (router.pathname === '/pull-requests'
+                                ? queryState === state
+                                : true)
+                        }
+                    />
+                )
+            )}
 
             {dev &&
                 devHeaderCategories.map(
-                    ({ title, refURL, pathName, state }, index) => (
+                    ({ title, refURL, pathName }, index) => (
                         <HeaderLink
                             key={index}
                             title={title}
                             link={refURL}
-                            isActive={
-                                router.pathname === pathName &&
-                                (router.pathname === '/pull-requests'
-                                    ? queryState === state
-                                    : true)
-                            }
+                            isActive={router.pathname === pathName}
                         />
                     )
                 )}

--- a/src/constants/header-categories.ts
+++ b/src/constants/header-categories.ts
@@ -16,13 +16,15 @@ export const headerCategories = [
     },
     {
         title: 'Open PRs',
-        refURL: '/openPRs',
-        pathName: '/openPRs',
+        refURL: '/pull-requests?state=open',
+        pathName: '/pull-requests',
+        state: 'open',
     },
     {
         title: 'Stale PRs',
-        refURL: '/stale-pr',
-        pathName: '/stale-pr',
+        refURL: '/pull-requests?state=stale',
+        pathName: '/pull-requests',
+        state: 'stale',
     },
     {
         title: 'Idle Users',
@@ -34,24 +36,12 @@ export const headerCategories = [
 export const devHeaderCategories = [
     {
         title: 'Standup',
-        refURL: '/standup/?dev=true',
+        refURL: '/standup?dev=true',
         pathName: '/standup',
     },
     {
         title: 'Availability Panel',
-        refURL: '/availability-panel',
+        refURL: '/availability-panel?dev=true',
         pathName: '/availability-panel',
-    },
-    {
-        title: 'Open PRs(dev)',
-        refURL: '/pull-requests?state=open&dev=true',
-        pathName: '/pull-requests',
-        state: 'open',
-    },
-    {
-        title: 'Stale PRs(dev)',
-        refURL: '/pull-requests?state=stale&dev=true',
-        pathName: '/pull-requests',
-        state: 'stale',
     },
 ];

--- a/src/pages/openPRs/index.tsx
+++ b/src/pages/openPRs/index.tsx
@@ -1,6 +1,0 @@
-import { FC } from 'react';
-import PullRequestList from '@/components/PullRequestList';
-
-const openPRs: FC = () => <PullRequestList prType="open" />;
-
-export default openPRs;

--- a/src/pages/stale-pr/index.tsx
+++ b/src/pages/stale-pr/index.tsx
@@ -1,6 +1,0 @@
-import { FC } from 'react';
-import PullRequestList from '@/components/PullRequestList';
-
-const stalePR: FC = () => <PullRequestList prType="stale" />;
-
-export default stalePR;


### PR DESCRIPTION
Closes #1029  
### Issue:
- #1029 
### Description:
Older pull requests routes(open prs and closed prs) with unconventional naming are replaced with updated routes which were under feature flag.

### Feature Flag:
This PR takes a feature(#935 ) out of feature flag.

### Frontend Changes
- [x] Yes
- [ ] No

### Backend Changes
- [ ] Yes
- [x] No

### Dev Tested:
- [x] Yes
- [ ] No

![Screenshot_test](https://github.com/Real-Dev-Squad/website-status/assets/87164140/49482ad1-13b3-490f-bc0b-09802c2ee6ff)
![Screenshot_coverage](https://github.com/Real-Dev-Squad/website-status/assets/87164140/b9e72fba-a79e-43a9-89f9-88ce87996367)



### Images/video of the change:
Before:

https://github.com/Real-Dev-Squad/website-status/assets/87164140/1654811f-5084-41e7-ab7c-659b9d16ebff


After:

https://github.com/Real-Dev-Squad/website-status/assets/87164140/5968eda3-1bef-4703-a0c7-61cc7394053d





