### PR TITLE
fix: added github issue link to task request post call

### DIFF
--- a/__tests__/Unit/hooks/taskRequestApi.test.tsx
+++ b/__tests__/Unit/hooks/taskRequestApi.test.tsx
@@ -81,4 +81,43 @@ describe('useAddOrUpdateMutation', () => {
         expect(response.isSuccess).toBe(false);
         expect(response.isError).toBe(true);
     });
+
+    it('should update successfully', async () => {
+        const { result, waitForNextUpdate } = renderHook(
+            () => useAddOrUpdateMutation(),
+            { wrapper: Wrapper }
+        );
+
+        const [addTask, initialResponse] = result.current;
+        expect(initialResponse.data).toBeUndefined();
+        expect(initialResponse.isLoading).toBe(false);
+
+        act(() => {
+            addTask({
+                taskId: 'taskId',
+                userId: 'userId',
+                externalIssueUrl:
+                    'https://api.github.com/repos/Real-Dev-Squad/website-status/issues/1050',
+                externalIssueHtmlUrl:
+                    'https://github.com/Real-Dev-Squad/website-status/issues/1050',
+                requestType: TASK_REQUEST_TYPES.ASSIGNMENT,
+                description: '',
+                proposedStartDate: Date.now(),
+                proposedDeadline: Date.now(),
+            });
+        });
+
+        expect(result.current[1].isLoading).toBe(true);
+
+        await act(() => waitForNextUpdate());
+
+        const response = result.current[1];
+        expect(response.data).not.toBeUndefined();
+        expect(response.data?.message).toBe(
+            'Task request successfully created'
+        );
+        expect(response.isLoading).toBe(false);
+        expect(response.isSuccess).toBe(true);
+        expect(response.isError).toBe(false);
+    });
 });

--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
     "test": "jest --coverage",
     "test-watch": "jest --watch ",
     "lint": "next lint",
-    "lint-fix": "eslint . --fix --ext js,jsx,ts,tsx",
+    "lint:fix": "eslint . --fix --ext js,jsx,ts,tsx",
     "postinstall": "husky install",
     "storybook": "start-storybook -s ./public -p 6006",
     "build-storybook": "build-storybook",
     "prettier": "npx prettier src __tests__ --check",
-    "prettier:fix": "npm run prettier -- --write"
-  },
+    "prettier:fix": "npm run prettier -- --write",
+    "fix": "yarn prettier:fix && yarn lint:fix"
+    },
   "repository": {
     "type": "git",
     "url": "https://github.com/Real-Dev-Squad/website-status.git"

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "test": "jest --coverage",
     "test-watch": "jest --watch ",
     "lint": "next lint",
-    "lint:fix": "eslint . --fix --ext js,jsx,ts,tsx",
+    "lint-fix": "eslint . --fix --ext js,jsx,ts,tsx",
     "postinstall": "husky install",
     "storybook": "start-storybook -s ./public -p 6006",
     "build-storybook": "build-storybook",
     "prettier": "npx prettier src __tests__ --check",
-    "prettier:fix": "npm run prettier -- --write",
-    "fix": "yarn prettier:fix && yarn lint:fix"
+    "prettier-fix": "npm run prettier -- --write",
+    "fix": "yarn prettier-fix && yarn lint-fix"
     },
   "repository": {
     "type": "git",

--- a/src/app/services/taskRequestApi.ts
+++ b/src/app/services/taskRequestApi.ts
@@ -4,6 +4,7 @@ type AddOrUpdateMutationQuery = {
     taskId?: string;
     userId?: string;
     externalIssueUrl?: string;
+    externalIssueHtmlUrl: string;
     requestType: string;
     description: string | undefined;
     proposedStartDate: number | string;

--- a/src/app/services/taskRequestApi.ts
+++ b/src/app/services/taskRequestApi.ts
@@ -4,7 +4,7 @@ type AddOrUpdateMutationQuery = {
     taskId?: string;
     userId?: string;
     externalIssueUrl?: string;
-    externalIssueHtmlUrl: string;
+    externalIssueHtmlUrl?: string;
     requestType: string;
     description: string | undefined;
     proposedStartDate: number | string;

--- a/src/components/issues/Card.tsx
+++ b/src/components/issues/Card.tsx
@@ -102,6 +102,7 @@ const Card: FC<IssueCardProps> = ({ issue }) => {
     const handleCreateTaskRequest = async (data: TaskRequestData) => {
         const requestData = {
             externalIssueUrl: issue.url,
+            externalIssueHtmlUrl: issue.html_url,
             userId: userData?.id,
             requestType: TASK_REQUEST_TYPES.CREATION,
             proposedStartDate: data.startedOn,


### PR DESCRIPTION
## Issue Ticket Number:- 
-  Real-Dev-Squad/website-status#1050

## Description: 
In this pull request, I have addressed the issue described in Real-Dev-Squad/website-status#1050. The problem was related to the absence of GitHub issue ticket links for tasks created via task requests. 

Is Under Feature Flag 
- [ ] Yes
- [x] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [x] Yes
- [ ] No

Tested in staging?

- [x] Yes
- [ ] No

### Add relevant Screenshot below ( e.g test coverage etc. )
| File                              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s |
|-----------------------------------|---------|----------|---------|---------|-------------------|
|  taskRequestApi.ts                     |     100 |      100 |     100 |     100 |                   
|  Card.tsx                              |   38.35 |    47.05 |    37.5 |   38.02 | ...18,123-153,205 

### Demo

https://github.com/Real-Dev-Squad/website-status/assets/70854507/1be0acef-9bbd-474c-a1b5-bbba58ce7c20

# Related
PR - https://github.com/Real-Dev-Squad/website-backend/pull/1793