### PR TITLE
Fix progress update form bugs

### DIFF
--- a/__tests__/Utils/getTotalMissedTaskProgressUpdate.test.ts
+++ b/__tests__/Utils/getTotalMissedTaskProgressUpdate.test.ts
@@ -1,0 +1,21 @@
+import { getTotalMissedTaskProgressUpdate } from '@/utils/getTotalMissedTaskProgressUpdate';
+
+describe('Get total missed task progress update', () => {
+    test('should return 1 if progress is not updated in last 3 days', () => {
+        jest.useFakeTimers().setSystemTime(new Date('13 january 2024'));
+        const result = getTotalMissedTaskProgressUpdate(1704795225 * 1000);
+        expect(result).toBe(1);
+    });
+
+    test('should return 0 if last progress is updated in 3 days', () => {
+        jest.useFakeTimers().setSystemTime(new Date('11 january 2024'));
+        const result = getTotalMissedTaskProgressUpdate(1704795225 * 1000);
+        expect(result).toBe(0);
+    });
+
+    test('should return 0 if the last progress is not updated in 3 days but the date includes sunday', () => {
+        jest.useFakeTimers().setSystemTime(new Date('8 january 2024'));
+        const result = getTotalMissedTaskProgressUpdate(1704445747000);
+        expect(result).toBe(0);
+    });
+});

--- a/src/app/services/progressesApi.ts
+++ b/src/app/services/progressesApi.ts
@@ -3,7 +3,7 @@ import { progressDetails } from '@/types/standup.type';
 
 type queryParamsType = {
     userId?: string;
-    taskId?: string;
+    taskId?: string | string[];
 };
 
 export const progressesApi = api.injectEndpoints({

--- a/src/components/ProgressForm/ProgressLayout.tsx
+++ b/src/components/ProgressForm/ProgressLayout.tsx
@@ -8,23 +8,51 @@ import ProgressForm from './ProgressForm';
 import styles from '@/components/ProgressForm/ProgressForm.module.scss';
 
 import { questions } from '@/constants/ProgressUpdates';
-import { getTotalMissedUpdates } from '@/utils/getTotalMissedUpdate';
+import { getTotalMissedTaskProgressUpdate } from '@/utils/getTotalMissedTaskProgressUpdate';
 import { useGetProgressDetailsQuery } from '@/app/services/progressesApi';
-import { useGetUserQuery } from '@/app/services/userApi';
+import { useGetTaskDetailsQuery } from '@/app/services/taskDetailsApi';
 
-const ProgressLayout: FC = () => {
-    const { data: user } = useGetUserQuery();
-    const { data: userStandupdata } = useGetProgressDetailsQuery({
-        userId: user?.id,
-    });
+interface ProgressLayoutPropsType {
+    taskId: string[] | undefined;
+}
+
+const ProgressLayout: FC<ProgressLayoutPropsType> = ({ taskId }) => {
+    const { data: userStandupdata, isLoading: isProgressUpdateDetailsLoading } =
+        useGetProgressDetailsQuery(
+            {
+                taskId: taskId,
+            },
+            { skip: taskId ? false : true }
+        );
+
+    const { data: taskDetailData, isLoading: isTaskDetailsLoading } =
+        useGetTaskDetailsQuery(taskId);
+
+    const taskStartedOn = taskDetailData?.taskData?.createdAt;
     const standupDates = userStandupdata?.data?.map((element) => element.date);
-    const totalMissedUpdates = getTotalMissedUpdates(standupDates || []);
+
+    let totalProgressMissedUpdates;
+
+    if (!isTaskDetailsLoading && !isProgressUpdateDetailsLoading) {
+        if (standupDates) {
+            totalProgressMissedUpdates = getTotalMissedTaskProgressUpdate(
+                standupDates[0]
+            );
+        } else {
+            totalProgressMissedUpdates = getTotalMissedTaskProgressUpdate(
+                taskStartedOn * 1000
+            );
+        }
+    } else {
+        totalProgressMissedUpdates = 0;
+    }
+
     return (
         <>
             <NavBar />
             <div className={styles.progressUpdateContainer}>
                 <ProgressHeader
-                    totalMissedUpdates={totalMissedUpdates}
+                    totalMissedUpdates={totalProgressMissedUpdates}
                     updateType="Progress"
                 />
                 <section className={styles.container}>

--- a/src/pages/progress/[id].tsx
+++ b/src/pages/progress/[id].tsx
@@ -12,7 +12,7 @@ const ProgressUpdatesPage = () => {
         return <PageNotFound />;
     }
 
-    return <ProgressLayout />;
+    return <ProgressLayout taskId={id} />;
 };
 
 export default ProgressUpdatesPage;

--- a/src/utils/getTotalMissedTaskProgressUpdate.ts
+++ b/src/utils/getTotalMissedTaskProgressUpdate.ts
@@ -1,0 +1,47 @@
+import { TOTAL_MILLISECONDS_IN_A_HOUR } from '@/constants/date';
+
+export function getTotalMissedTaskProgressUpdate(lastUpdated: number) {
+    const presentDateInUtc = new Date().toUTCString();
+    const taskLastUpdatedOn = new Date(lastUpdated).toUTCString();
+
+    const presentDateMillisecond = new Date(presentDateInUtc).valueOf();
+    const taskStartedOnMillisecond = new Date(taskLastUpdatedOn).valueOf();
+
+    let count = 0;
+    const sundays = getSundays(lastUpdated);
+
+    const differenceInHours = Math.round(
+        (presentDateMillisecond - taskStartedOnMillisecond) /
+            TOTAL_MILLISECONDS_IN_A_HOUR
+    );
+
+    let missedProgressUpdate = Math.round(differenceInHours / 24);
+    if (sundays !== 0) {
+        missedProgressUpdate = missedProgressUpdate - sundays;
+    }
+
+    if (missedProgressUpdate >= 3) {
+        for (let i = 1; i <= missedProgressUpdate; i++) {
+            if (i % 3 === 0) {
+                count++;
+            }
+        }
+        return count;
+    } else {
+        return count;
+    }
+}
+
+function getSundays(taskStartedOn: number) {
+    const taskStartedOnDate = new Date(taskStartedOn);
+    const currentDate = new Date();
+    let sundays = 0;
+
+    while (taskStartedOnDate <= currentDate) {
+        if (taskStartedOnDate.getDay() === 0) {
+            sundays++;
+        }
+        taskStartedOnDate.setDate(taskStartedOnDate.getDate() + 1);
+    }
+    return sundays;
+}


### PR DESCRIPTION
## Issue Ticket Number
**Closes**: https://github.com/Real-Dev-Squad/website-status/issues/1071

## Description
- Now `/progress` API in only called once.
- Fix the response of `/progress` API now it shows task progress updates.
- Wrong missed progress count is being shown on page it is also fix created util function for it.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
In this example, an issue was created on January 9, 2024. Since then, there has been no progress update, resulting in a count of 1. Additionally, there is one Sunday on January 14, 2024. If Sunday were not present, the count could have been 2.

https://github.com/Real-Dev-Squad/website-status/assets/22213872/18af588b-f299-45a7-8024-99596c16b96b



<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage

Util function test coverage:-

![image](https://github.com/Real-Dev-Squad/website-status/assets/22213872/27f935ca-f51f-4de0-89bd-bee687673edc)

![image](https://github.com/Real-Dev-Squad/website-status/assets/22213872/5874943e-7b3e-47e7-b063-e9e1984458f8)

Test coverage

![image](https://github.com/Real-Dev-Squad/website-status/assets/22213872/0bb5262e-1e1b-4014-b84e-b56b5c81fb9c)



<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
