### PR TITLE
feat/issue-1088:  show icon for pending extension request for a task

### DIFF
--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -248,6 +248,22 @@ describe('TaskDetails Page', () => {
             'https://dashboard.realdevsquad.com/extension-requests?order=asc&q=taskId%3AzlwjJzKbGpqCoCTZMZQy'
         );
     });
+    it('Doesnot Renders Extension Request icon when url not available', async () => {
+        const { getByText } = renderWithRouter(
+            <Provider store={store()}>
+                <Details
+                    detailType={'Ends On'}
+                    value={'4/19/2021, 12:00:10 AM'}
+                    url={null}
+                />
+            </Provider>
+        );
+        const element = screen.queryByTestId('element-to-test');
+        expect(element).toBeNull();
+        await waitFor(() => {
+            expect(getByText('4/19/2021, 12:00:10 AM')).toBeInTheDocument();
+        });
+    });
 
     test('should update taskDetails and editedDetails correctly on input change', async () => {
         renderWithRouter(

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -15,6 +15,7 @@ import Details from '@/components/taskDetails/Details';
 import { taskRequestErrorHandler } from '../../../../__mocks__/handlers/task-request.handler';
 import { taskDetailsHandler } from '../../../../__mocks__/handlers/task-details.handler';
 import { superUserSelfHandler } from '../../../../__mocks__/handlers/self.handler';
+import DevFeature from '@/components/DevFeature';
 
 const details = {
     url: 'https://realdevsquad.com/tasks/6KhcLU3yr45dzjQIVm0J/details',
@@ -237,17 +238,22 @@ describe('TaskDetails Page', () => {
                     value={'4/19/2021, 12:00:10 AM'}
                     url={details.extension_request_url}
                 />
-            </Provider>
+            </Provider>,
+            {
+                query: { dev: 'true' },
+            }
         );
-        const element = screen.getByTestId('extension-request-icon');
+
         await waitFor(() => {
+            const element = screen.queryByTestId('extension-request-icon');
+            expect(element).toHaveAttribute(
+                'href',
+                'https://dashboard.realdevsquad.com/extension-requests?order=asc&q=taskId%3AzlwjJzKbGpqCoCTZMZQy'
+            );
             expect(getByText('4/19/2021, 12:00:10 AM')).toBeInTheDocument();
         });
-        expect(element).toHaveAttribute(
-            'href',
-            'https://dashboard.realdevsquad.com/extension-requests?order=asc&q=taskId%3AzlwjJzKbGpqCoCTZMZQy'
-        );
     });
+
     it('Doesnot Renders Extension Request icon when url not available', async () => {
         const { getByText } = renderWithRouter(
             <Provider store={store()}>
@@ -256,9 +262,12 @@ describe('TaskDetails Page', () => {
                     value={'4/19/2021, 12:00:10 AM'}
                     url={null}
                 />
-            </Provider>
+            </Provider>,
+            {
+                query: { dev: 'true' },
+            }
         );
-        const element = screen.queryByTestId('element-to-test');
+        const element = screen.queryByTestId('extension-request-icon');
         expect(element).toBeNull();
         await waitFor(() => {
             expect(getByText('4/19/2021, 12:00:10 AM')).toBeInTheDocument();

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -19,6 +19,8 @@ import { superUserSelfHandler } from '../../../../__mocks__/handlers/self.handle
 const details = {
     url: 'https://realdevsquad.com/tasks/6KhcLU3yr45dzjQIVm0J/details',
     taskID: '6KhcLU3yr45dzjQIVm0J',
+    extension_request_url:
+        'https://dashboard.realdevsquad.com/extension-requests?order=asc&q=taskId%3AzlwjJzKbGpqCoCTZMZQy',
 };
 
 const server = setupServer(...handlers);
@@ -225,6 +227,26 @@ describe('TaskDetails Page', () => {
         await waitFor(() => {
             expect(getByText('4/19/2021, 12:00:10 AM')).toBeInTheDocument();
         });
+    });
+
+    it('Renders Extension Request icon', async () => {
+        const { getByText } = renderWithRouter(
+            <Provider store={store()}>
+                <Details
+                    detailType={'Ends On'}
+                    value={'4/19/2021, 12:00:10 AM'}
+                    url={details.extension_request_url}
+                />
+            </Provider>
+        );
+        const element = screen.getByTestId('extension-request-icon');
+        await waitFor(() => {
+            expect(getByText('4/19/2021, 12:00:10 AM')).toBeInTheDocument();
+        });
+        expect(element).toHaveAttribute(
+            'href',
+            'https://dashboard.realdevsquad.com/extension-requests?order=asc&q=taskId%3AzlwjJzKbGpqCoCTZMZQy'
+        );
     });
 
     test('should update taskDetails and editedDetails correctly on input change', async () => {

--- a/src/app/services/taskDetailsApi.ts
+++ b/src/app/services/taskDetailsApi.ts
@@ -1,4 +1,4 @@
-import { TASKS_URL } from '@/constants/url';
+import { BASE_URL, TASKS_URL } from '@/constants/url';
 import { api } from './api';
 import { taskDetailsDataType } from '@/interfaces/taskDetails.type';
 import {
@@ -73,6 +73,10 @@ export const taskDetailsApi = api.injectEndpoints({
             },
             invalidatesTags: ['Task_Details'],
         }),
+        getExtensionRequestDetails: build.query<taskDetailsDataType, string>({
+            query: (taskId): string =>
+                `${BASE_URL}/extension-requests?q=status%3APENDING%2CtaskId%3A${taskId}`,
+        }),
     }),
     overrideExisting: true,
 });
@@ -81,4 +85,5 @@ export const {
     useGetTaskDetailsQuery,
     useUpdateTaskDetailsMutation,
     useGetTasksDependencyDetailsQuery,
+    useGetExtensionRequestDetailsQuery,
 } = taskDetailsApi;

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -35,7 +35,7 @@ const Details: FC<TaskDetailsProps> = ({ detailType, value, url }) => {
             </span>
             <span>
                 {detailType === 'Ends On' && url && (
-                    <Link href={url}>
+                    <Link href={url} data-testid="extension-request-icon">
                         <FaReceipt color="green" />
                     </Link>
                 )}

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -3,8 +3,15 @@ import setColor from './taskPriorityColors';
 import styles from './task-details.module.scss';
 import { TaskDetailsProps } from '@/interfaces/taskDetails.type';
 import extractRepoName from '@/utils/extractRepoName';
+import Link from 'next/link';
 
-const Details: FC<TaskDetailsProps> = ({ detailType, value }) => {
+const Details: FC<TaskDetailsProps> = ({
+    detailType,
+    value,
+    icon,
+    icon_url,
+    showIcon,
+}) => {
     const color = value ? setColor?.[value] : undefined;
     const isGitHubLink = detailType === 'Link';
     const gitHubIssueLink = isGitHubLink ? value : undefined;
@@ -30,6 +37,9 @@ const Details: FC<TaskDetailsProps> = ({ detailType, value }) => {
                 ) : (
                     <>{isGitHubLink ? 'N/A' : value ?? 'N/A'}</>
                 )}
+            </span>
+            <span>
+                {icon && showIcon && <Link href={`${icon_url}`}>{icon}</Link>}
             </span>
         </div>
     );

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -5,6 +5,7 @@ import { TaskDetailsProps } from '@/interfaces/taskDetails.type';
 import extractRepoName from '@/utils/extractRepoName';
 import Link from 'next/link';
 import { FaReceipt } from 'react-icons/fa6';
+import DevFeature from '../DevFeature';
 
 const Details: FC<TaskDetailsProps> = ({ detailType, value, url }) => {
     const color = value ? setColor?.[value] : undefined;
@@ -33,13 +34,15 @@ const Details: FC<TaskDetailsProps> = ({ detailType, value, url }) => {
                     <>{isGitHubLink ? 'N/A' : value ?? 'N/A'}</>
                 )}
             </span>
-            <span>
-                {detailType === 'Ends On' && url && (
-                    <Link href={url} data-testid="extension-request-icon">
-                        <FaReceipt color="green" />
-                    </Link>
-                )}
-            </span>
+            <DevFeature>
+                <span>
+                    {detailType === 'Ends On' && url && (
+                        <Link href={url} data-testid="extension-request-icon">
+                            <FaReceipt color="green" />
+                        </Link>
+                    )}
+                </span>
+            </DevFeature>
         </div>
     );
 };

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -4,14 +4,9 @@ import styles from './task-details.module.scss';
 import { TaskDetailsProps } from '@/interfaces/taskDetails.type';
 import extractRepoName from '@/utils/extractRepoName';
 import Link from 'next/link';
+import { FaReceipt } from 'react-icons/fa6';
 
-const Details: FC<TaskDetailsProps> = ({
-    detailType,
-    value,
-    icon,
-    icon_url,
-    showIcon,
-}) => {
+const Details: FC<TaskDetailsProps> = ({ detailType, value, url }) => {
     const color = value ? setColor?.[value] : undefined;
     const isGitHubLink = detailType === 'Link';
     const gitHubIssueLink = isGitHubLink ? value : undefined;
@@ -39,7 +34,11 @@ const Details: FC<TaskDetailsProps> = ({
                 )}
             </span>
             <span>
-                {icon && showIcon && <Link href={`${icon_url}`}>{icon}</Link>}
+                {detailType === 'Ends On' && url && (
+                    <Link href={url}>
+                        <FaReceipt color="green" />
+                    </Link>
+                )}
             </span>
         </div>
     );

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -482,7 +482,7 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
                                     className={styles.button}
                                     onClick={() =>
                                         router.push(
-                                            `/progress/${taskID}?dev=false`
+                                            `/progress/${taskID}?dev=true`
                                         )
                                     }
                                 >

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -219,6 +219,15 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
         return timestamp ? convertTimeStamp(timestamp) : 'TBD';
     }
 
+    function getExtensionRequestLink(
+        taskId: string,
+        isExtensionRequestPending?: boolean
+    ) {
+        return isExtensionRequestPending
+            ? `${TASK_EXTENSION_REQUEST_URL}?taskId=${taskId}`
+            : null;
+    }
+
     const shouldRenderParentContainer = () => !isLoading && !isError && data;
 
     const { data: progressData } = useGetProgressDetailsQuery({
@@ -435,11 +444,10 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
                                 <Details
                                     detailType={'Ends On'}
                                     value={getEndsOn(taskDetailsData?.endsOn)}
-                                    icon={<FaReceipt color="green" />}
-                                    icon_url={`${TASK_EXTENSION_REQUEST_URL}?taskId=${taskDetailsData?.id}`}
-                                    showIcon={
-                                        taskDetailsData?.isPendingExtensionRequest
-                                    }
+                                    url={getExtensionRequestLink(
+                                        taskDetailsData.id,
+                                        taskDetailsData.isExtensionRequestPending
+                                    )}
                                 />
 
                                 <DevFeature>

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -30,6 +30,8 @@ import DevFeature from '../DevFeature';
 import Suggestions from '../tasks/SuggestionBox/Suggestions';
 import { BACKEND_TASK_STATUS } from '@/constants/task-status';
 import task from '@/interfaces/task.type';
+import { FaReceipt } from 'react-icons/fa6';
+import { TASK_EXTENSION_REQUEST_URL } from '@/constants/url';
 
 const taskStatus = Object.entries(BACKEND_TASK_STATUS);
 
@@ -430,11 +432,16 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
                                         taskDetailsData?.startedOn
                                     )}
                                 />
-
                                 <Details
                                     detailType={'Ends On'}
                                     value={getEndsOn(taskDetailsData?.endsOn)}
+                                    icon={<FaReceipt color="green" />}
+                                    icon_url={`${TASK_EXTENSION_REQUEST_URL}?taskId=${taskDetailsData?.id}`}
+                                    showIcon={
+                                        taskDetailsData?.isPendingExtensionRequest
+                                    }
                                 />
+
                                 <DevFeature>
                                     {isEditing && (
                                         <>
@@ -467,7 +474,7 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
                                     className={styles.button}
                                     onClick={() =>
                                         router.push(
-                                            `/progress/${taskID}?dev=true`
+                                            `/progress/${taskID}?dev=false`
                                         )
                                     }
                                 >

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -31,7 +31,6 @@ import DevFeature from '../DevFeature';
 import Suggestions from '../tasks/SuggestionBox/Suggestions';
 import { BACKEND_TASK_STATUS } from '@/constants/task-status';
 import task from '@/interfaces/task.type';
-import { FaReceipt } from 'react-icons/fa6';
 import { TASK_EXTENSION_REQUEST_URL } from '@/constants/url';
 
 const taskStatus = Object.entries(BACKEND_TASK_STATUS);

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -85,7 +85,7 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
     const { data: extensionRequests } =
         useGetExtensionRequestDetailsQuery(taskID);
     const isExtensionRequestPending = Boolean(
-        extensionRequests?.allExtensionRequests.length || []
+        extensionRequests?.allExtensionRequests.length
     );
     const taskDependencyIds: string[] = !isFetching
         ? data?.taskData?.dependsOn || []

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -6,6 +6,7 @@ import convertTimeStamp from '@/helperFunctions/convertTimeStamp';
 import styles from './task-details.module.scss';
 import { useRouter } from 'next/router';
 import {
+    useGetExtensionRequestDetailsQuery,
     useGetTaskDetailsQuery,
     useUpdateTaskDetailsMutation,
 } from '@/app/services/taskDetailsApi';
@@ -81,7 +82,11 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
     const [isEditing, setIsEditing] = useState<boolean>(false);
     const { data, isError, isLoading, isFetching } =
         useGetTaskDetailsQuery(taskID);
-
+    const { data: extensionRequests } =
+        useGetExtensionRequestDetailsQuery(taskID);
+    const isExtensionRequestPending = Boolean(
+        extensionRequests?.allExtensionRequests.length || []
+    );
     const taskDependencyIds: string[] = !isFetching
         ? data?.taskData?.dependsOn || []
         : [];
@@ -446,7 +451,7 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
                                     value={getEndsOn(taskDetailsData?.endsOn)}
                                     url={getExtensionRequestLink(
                                         taskDetailsData.id,
-                                        taskDetailsData.isExtensionRequestPending
+                                        isExtensionRequestPending
                                     )}
                                 />
 

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -33,3 +33,4 @@ export const MY_SITE_URL = 'https://my.realdevsquad.com';
 export const DASHBOARD_URL = 'https://dashboard.realdevsquad.com';
 export const USER_MANAGEMENT_URL = `${DASHBOARD_URL}/users/details/`;
 export const TASK_REQUESTS_DETAILS_URL = `${DASHBOARD_URL}/task-requests/details/`;
+export const TASK_EXTENSION_REQUEST_URL = `${DASHBOARD_URL}/extension-requests/`;

--- a/src/interfaces/task.type.ts
+++ b/src/interfaces/task.type.ts
@@ -33,7 +33,6 @@ type task = {
     };
     status: string; // Update the type of task status once this is addressed https://github.com/Real-Dev-Squad/website-status/issues/1002
     priority: string;
-    isExtensionRequestPending?: boolean;
 };
 
 export type TasksResponseType = {

--- a/src/interfaces/task.type.ts
+++ b/src/interfaces/task.type.ts
@@ -33,6 +33,7 @@ type task = {
     };
     status: string; // Update the type of task status once this is addressed https://github.com/Real-Dev-Squad/website-status/issues/1002
     priority: string;
+    isPendingExtensionRequest?: boolean;
 };
 
 export type TasksResponseType = {

--- a/src/interfaces/task.type.ts
+++ b/src/interfaces/task.type.ts
@@ -33,7 +33,7 @@ type task = {
     };
     status: string; // Update the type of task status once this is addressed https://github.com/Real-Dev-Squad/website-status/issues/1002
     priority: string;
-    isPendingExtensionRequest?: boolean;
+    isExtensionRequestPending?: boolean;
 };
 
 export type TasksResponseType = {

--- a/src/interfaces/taskDetails.type.ts
+++ b/src/interfaces/taskDetails.type.ts
@@ -29,6 +29,9 @@ export type DependencyListProps = {
 export type TaskDetailsProps = {
     detailType: string;
     value?: string;
+    icon_url?: string;
+    icon?: React.ReactElement;
+    showIcon?: boolean;
 };
 export type DependencyItem =
     | PromiseFulfilledResult<{

--- a/src/interfaces/taskDetails.type.ts
+++ b/src/interfaces/taskDetails.type.ts
@@ -3,6 +3,7 @@ import task from './task.type';
 export type taskDetailsDataType = {
     message?: string;
     taskData?: task;
+    allExtensionRequests: [];
 };
 
 export type ButtonProps = {

--- a/src/interfaces/taskDetails.type.ts
+++ b/src/interfaces/taskDetails.type.ts
@@ -29,9 +29,7 @@ export type DependencyListProps = {
 export type TaskDetailsProps = {
     detailType: string;
     value?: string;
-    icon_url?: string;
-    icon?: React.ReactElement;
-    showIcon?: boolean;
+    url?: string | null;
 };
 export type DependencyItem =
     | PromiseFulfilledResult<{


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 29/01/2024
<!--Developer Name Here-->
Developer Name: Palak Gupta (palakgupta2712)

---

## Issue Ticket Number
resolves #1088 

## Description
Conditionally show the icon that will redirect user to extension-requests/taskId={taskId}, only if there is any pending extension request for that particular task.

### Documentation Updated?

- [ ] Yes
- [x] No
As per current documentation format, so changes were made.


<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Scenario 1</summary>
- isPendingExtensionRequest is `false` for that task, 

![image](https://github.com/Real-Dev-Squad/website-status/assets/61227144/053b8a8d-cffe-4ed3-8ed4-7dceffa8ddc3)

<img width="446" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/61227144/a23cd272-a46e-435e-98cb-db5f0ec54b3f">

</details>

<details>
<summary>Scenario 2</summary>
- isPendingExtensionRequest is `true` for that task,
- On clicking the icon it will redirect to `/extension-requests?order=asc&q=taskId%{taskId}`

![image](https://github.com/Real-Dev-Squad/website-status/assets/61227144/43f25968-deab-4f74-944b-b31eceb6c6af)

<img width="418" alt="image" src="https://github.com/Real-Dev-Squad/website-status/assets/61227144/c8943c5f-7048-45d7-bba3-93a74b33db65"></details>
<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>test covergae</summary>

![image](https://github.com/Real-Dev-Squad/website-status/assets/61227144/e924015f-ffed-4d5e-a7b3-1d35c41deb3b)
</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
