### PR TITLE
feat/issue-1088:  dev to main sync

### DIFF
--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -15,10 +15,13 @@ import Details from '@/components/taskDetails/Details';
 import { taskRequestErrorHandler } from '../../../../__mocks__/handlers/task-request.handler';
 import { taskDetailsHandler } from '../../../../__mocks__/handlers/task-details.handler';
 import { superUserSelfHandler } from '../../../../__mocks__/handlers/self.handler';
+import DevFeature from '@/components/DevFeature';
 
 const details = {
     url: 'https://realdevsquad.com/tasks/6KhcLU3yr45dzjQIVm0J/details',
     taskID: '6KhcLU3yr45dzjQIVm0J',
+    extension_request_url:
+        'https://dashboard.realdevsquad.com/extension-requests?order=asc&q=taskId%3AzlwjJzKbGpqCoCTZMZQy',
 };
 
 const server = setupServer(...handlers);
@@ -222,6 +225,50 @@ describe('TaskDetails Page', () => {
                 />
             </Provider>
         );
+        await waitFor(() => {
+            expect(getByText('4/19/2021, 12:00:10 AM')).toBeInTheDocument();
+        });
+    });
+
+    it('Renders Extension Request icon', async () => {
+        const { getByText } = renderWithRouter(
+            <Provider store={store()}>
+                <Details
+                    detailType={'Ends On'}
+                    value={'4/19/2021, 12:00:10 AM'}
+                    url={details.extension_request_url}
+                />
+            </Provider>,
+            {
+                query: { dev: 'true' },
+            }
+        );
+
+        await waitFor(() => {
+            const element = screen.queryByTestId('extension-request-icon');
+            expect(element).toHaveAttribute(
+                'href',
+                'https://dashboard.realdevsquad.com/extension-requests?order=asc&q=taskId%3AzlwjJzKbGpqCoCTZMZQy'
+            );
+            expect(getByText('4/19/2021, 12:00:10 AM')).toBeInTheDocument();
+        });
+    });
+
+    it('Doesnot Renders Extension Request icon when url not available', async () => {
+        const { getByText } = renderWithRouter(
+            <Provider store={store()}>
+                <Details
+                    detailType={'Ends On'}
+                    value={'4/19/2021, 12:00:10 AM'}
+                    url={null}
+                />
+            </Provider>,
+            {
+                query: { dev: 'true' },
+            }
+        );
+        const element = screen.queryByTestId('extension-request-icon');
+        expect(element).toBeNull();
         await waitFor(() => {
             expect(getByText('4/19/2021, 12:00:10 AM')).toBeInTheDocument();
         });

--- a/src/app/services/taskDetailsApi.ts
+++ b/src/app/services/taskDetailsApi.ts
@@ -1,4 +1,4 @@
-import { TASKS_URL } from '@/constants/url';
+import { BASE_URL, TASKS_URL } from '@/constants/url';
 import { api } from './api';
 import { taskDetailsDataType } from '@/interfaces/taskDetails.type';
 import {
@@ -73,6 +73,10 @@ export const taskDetailsApi = api.injectEndpoints({
             },
             invalidatesTags: ['Task_Details'],
         }),
+        getExtensionRequestDetails: build.query<taskDetailsDataType, string>({
+            query: (taskId): string =>
+                `${BASE_URL}/extension-requests?q=status%3APENDING%2CtaskId%3A${taskId}`,
+        }),
     }),
     overrideExisting: true,
 });
@@ -81,4 +85,5 @@ export const {
     useGetTaskDetailsQuery,
     useUpdateTaskDetailsMutation,
     useGetTasksDependencyDetailsQuery,
+    useGetExtensionRequestDetailsQuery,
 } = taskDetailsApi;

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -3,8 +3,11 @@ import setColor from './taskPriorityColors';
 import styles from './task-details.module.scss';
 import { TaskDetailsProps } from '@/interfaces/taskDetails.type';
 import extractRepoName from '@/utils/extractRepoName';
+import Link from 'next/link';
+import { FaReceipt } from 'react-icons/fa6';
+import DevFeature from '../DevFeature';
 
-const Details: FC<TaskDetailsProps> = ({ detailType, value }) => {
+const Details: FC<TaskDetailsProps> = ({ detailType, value, url }) => {
     const color = value ? setColor?.[value] : undefined;
     const isGitHubLink = detailType === 'Link';
     const gitHubIssueLink = isGitHubLink ? value : undefined;
@@ -31,6 +34,15 @@ const Details: FC<TaskDetailsProps> = ({ detailType, value }) => {
                     <>{isGitHubLink ? 'N/A' : value ?? 'N/A'}</>
                 )}
             </span>
+            <DevFeature>
+                <span>
+                    {detailType === 'Ends On' && url && (
+                        <Link href={url} data-testid="extension-request-icon">
+                            <FaReceipt color="green" />
+                        </Link>
+                    )}
+                </span>
+            </DevFeature>
         </div>
     );
 };

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -6,6 +6,7 @@ import convertTimeStamp from '@/helperFunctions/convertTimeStamp';
 import styles from './task-details.module.scss';
 import { useRouter } from 'next/router';
 import {
+    useGetExtensionRequestDetailsQuery,
     useGetTaskDetailsQuery,
     useUpdateTaskDetailsMutation,
 } from '@/app/services/taskDetailsApi';
@@ -30,6 +31,7 @@ import DevFeature from '../DevFeature';
 import Suggestions from '../tasks/SuggestionBox/Suggestions';
 import { BACKEND_TASK_STATUS } from '@/constants/task-status';
 import task from '@/interfaces/task.type';
+import { TASK_EXTENSION_REQUEST_URL } from '@/constants/url';
 
 const taskStatus = Object.entries(BACKEND_TASK_STATUS);
 
@@ -79,7 +81,11 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
     const [isEditing, setIsEditing] = useState<boolean>(false);
     const { data, isError, isLoading, isFetching } =
         useGetTaskDetailsQuery(taskID);
-
+    const { data: extensionRequests } =
+        useGetExtensionRequestDetailsQuery(taskID);
+    const isExtensionRequestPending = Boolean(
+        extensionRequests?.allExtensionRequests.length
+    );
     const taskDependencyIds: string[] = !isFetching
         ? data?.taskData?.dependsOn || []
         : [];
@@ -215,6 +221,15 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
 
     function getEndsOn(timestamp: number | undefined) {
         return timestamp ? convertTimeStamp(timestamp) : 'TBD';
+    }
+
+    function getExtensionRequestLink(
+        taskId: string,
+        isExtensionRequestPending?: boolean
+    ) {
+        return isExtensionRequestPending
+            ? `${TASK_EXTENSION_REQUEST_URL}?taskId=${taskId}`
+            : null;
     }
 
     const shouldRenderParentContainer = () => !isLoading && !isError && data;
@@ -430,11 +445,15 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
                                         taskDetailsData?.startedOn
                                     )}
                                 />
-
                                 <Details
                                     detailType={'Ends On'}
                                     value={getEndsOn(taskDetailsData?.endsOn)}
+                                    url={getExtensionRequestLink(
+                                        taskDetailsData.id,
+                                        isExtensionRequestPending
+                                    )}
                                 />
+
                                 <DevFeature>
                                     {isEditing && (
                                         <>

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -33,3 +33,4 @@ export const MY_SITE_URL = 'https://my.realdevsquad.com';
 export const DASHBOARD_URL = 'https://dashboard.realdevsquad.com';
 export const USER_MANAGEMENT_URL = `${DASHBOARD_URL}/users/details/`;
 export const TASK_REQUESTS_DETAILS_URL = `${DASHBOARD_URL}/task-requests/details/`;
+export const TASK_EXTENSION_REQUEST_URL = `${DASHBOARD_URL}/extension-requests/`;

--- a/src/interfaces/taskDetails.type.ts
+++ b/src/interfaces/taskDetails.type.ts
@@ -3,6 +3,7 @@ import task from './task.type';
 export type taskDetailsDataType = {
     message?: string;
     taskData?: task;
+    allExtensionRequests: [];
 };
 
 export type ButtonProps = {
@@ -29,6 +30,7 @@ export type DependencyListProps = {
 export type TaskDetailsProps = {
     detailType: string;
     value?: string;
+    url?: string | null;
 };
 export type DependencyItem =
     | PromiseFulfilledResult<{


### PR DESCRIPTION
…(#1095)

* feat/issue-1088:  show icon for pending extension request for a task in tasks details page

<!-- Date Here in dd mmm yyyy-->
Date: 2/02/2034
<!--Developer Name Here-->
Developer Name: Palak Gupta

---
## PR 
https://github.com/Real-Dev-Squad/website-status/pull/1095

## Issue Ticket Number
<!--Issue ticket this PR closes-->
#1088 

## Description
Conditionally show the icon that will redirect user to extension-requests/taskId={taskId}, only if there is any pending extension request for that particular task.

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->
Tested in staging
- [x] Yes
- [ ] No

### Staging Proof:

Staging proof for #1088 

https://github.com/Real-Dev-Squad/website-status/assets/61227144/6369dc78-dba4-45f4-b902-7a44d0fb13c2

