### PR TITLE
Add tests to calendar page for steady status data.

### DIFF
--- a/__tests__/Unit/pages/calendar/calendar.test.tsx
+++ b/__tests__/Unit/pages/calendar/calendar.test.tsx
@@ -52,7 +52,7 @@ describe('Calendar Page', () => {
         });
     });
 
-    it('displays holiday message on clicking a Sunday', async () => {
+    it('displays holiday message clicking on a Sunday', async () => {
         const { getByText, getByRole, getByPlaceholderText, getByTestId } =
             renderWithRouter(
                 <Provider store={store()}>

--- a/__tests__/Unit/pages/calendar/calendar.test.tsx
+++ b/__tests__/Unit/pages/calendar/calendar.test.tsx
@@ -1,0 +1,123 @@
+import { store } from '@/app/store';
+import { MONTHS } from '@/constants/calendar';
+import UserStatusCalendar from '@/pages/calendar';
+import { renderWithRouter } from '@/test_utils/createMockRouter';
+import { waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setupServer } from 'msw/node';
+import { Provider } from 'react-redux';
+import handlers from '../../../../__mocks__/handlers';
+
+const server = setupServer(...handlers);
+
+beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'error' });
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('Calendar Page', () => {
+    it('renders calendar page with input and button', () => {
+        const { getByPlaceholderText, getByRole } = renderWithRouter(
+            <Provider store={store()}>
+                <UserStatusCalendar />
+            </Provider>
+        );
+
+        const input = getByPlaceholderText('Enter username');
+        const button = getByRole('button', { name: 'Submit' });
+
+        expect(input).toBeInTheDocument();
+        expect(button).toBeInTheDocument();
+        expect(button).toBeDisabled();
+    });
+
+    it('should render calendar when user is selected', async () => {
+        const { getByTestId, getByPlaceholderText, getByRole } =
+            renderWithRouter(
+                <Provider store={store()}>
+                    <UserStatusCalendar />
+                </Provider>
+            );
+
+        const input = getByPlaceholderText('Enter username');
+        userEvent.type(input, 'muhammadmusab');
+        await waitFor(() => expect(input).toHaveValue('muhammadmusab'));
+
+        const button = getByRole('button', { name: 'Submit' });
+        userEvent.click(button);
+        await waitFor(() => {
+            const calendar = getByTestId('react-calendar');
+            expect(calendar).toBeInTheDocument;
+        });
+    });
+
+    it('displays holiday message on clicking a Sunday', async () => {
+        const { getByText, getByRole, getByPlaceholderText, getByTestId } =
+            renderWithRouter(
+                <Provider store={store()}>
+                    <UserStatusCalendar />
+                </Provider>
+            );
+
+        const input = getByPlaceholderText('Enter username');
+        userEvent.type(input, 'muhammadmusab');
+        await waitFor(() => expect(input).toHaveValue('muhammadmusab'));
+
+        const button = getByRole('button', { name: 'Submit' });
+        userEvent.click(button);
+        await waitFor(() => {
+            const calendar = getByTestId('react-calendar');
+            expect(calendar).toBeInTheDocument;
+        });
+
+        userEvent.click(getByRole('button', { name: 'February 18, 2024' }));
+
+        await waitFor(() => {
+            expect(
+                getByText('18-February-2024 is HOLIDAY(SUNDAY)!')
+            ).toBeInTheDocument();
+        });
+    });
+
+    it('displays appropriate message based on selected date', async () => {
+        const { getByText, getByRole, getByPlaceholderText, getByTestId } =
+            renderWithRouter(
+                <Provider store={store()}>
+                    <UserStatusCalendar />
+                </Provider>
+            );
+
+        const input = getByPlaceholderText('Enter username');
+        userEvent.type(input, 'muhammadmusab');
+        await waitFor(() => expect(input).toHaveValue('muhammadmusab'));
+
+        const button = getByRole('button', { name: 'Submit' });
+        userEvent.click(button);
+        await waitFor(() => {
+            const calendar = getByTestId('react-calendar');
+            expect(calendar).toBeInTheDocument;
+        });
+
+        const currentDate = new Date();
+        const formattedDate = `${
+            MONTHS[currentDate.getMonth()]
+        } ${currentDate.getDate()}, ${currentDate.getFullYear()}`;
+
+        userEvent.click(getByRole('button', { name: formattedDate }));
+
+        await waitFor(() => {
+            let expectedMessage;
+            const fullDate = `${currentDate.getDate()}-${
+                MONTHS[currentDate.getMonth()]
+            }-${currentDate.getFullYear()}`;
+            if (currentDate.getDay() === 0) {
+                expectedMessage = `${fullDate} is HOLIDAY(SUNDAY)!`;
+            } else {
+                expectedMessage = `No user status found for muhammadmusab on ${fullDate}!`;
+            }
+
+            expect(getByText(expectedMessage)).toBeInTheDocument();
+        });
+    });
+});

--- a/__tests__/Unit/pages/calendar/calendar.test.tsx
+++ b/__tests__/Unit/pages/calendar/calendar.test.tsx
@@ -71,53 +71,24 @@ describe('Calendar Page', () => {
             expect(calendar).toBeInTheDocument;
         });
 
-        userEvent.click(getByRole('button', { name: 'February 18, 2024' }));
-
-        await waitFor(() => {
-            expect(
-                getByText('18-February-2024 is HOLIDAY(SUNDAY)!')
-            ).toBeInTheDocument();
-        });
-    });
-
-    it('displays appropriate message based on selected date', async () => {
-        const { getByText, getByRole, getByPlaceholderText, getByTestId } =
-            renderWithRouter(
-                <Provider store={store()}>
-                    <UserStatusCalendar />
-                </Provider>
-            );
-
-        const input = getByPlaceholderText('Enter username');
-        userEvent.type(input, 'muhammadmusab');
-        await waitFor(() => expect(input).toHaveValue('muhammadmusab'));
-
-        const button = getByRole('button', { name: 'Submit' });
-        userEvent.click(button);
-        await waitFor(() => {
-            const calendar = getByTestId('react-calendar');
-            expect(calendar).toBeInTheDocument;
-        });
-
         const currentDate = new Date();
-        const formattedDate = `${
+        currentDate.setDate(1);
+        while (currentDate.getDay() !== 0) {
+            currentDate.setDate(currentDate.getDate() + 1);
+        }
+        const formattedSundayDate = `${currentDate.getDate()}-${
+            MONTHS[currentDate.getMonth()]
+        }-${currentDate.getFullYear()}`;
+        const fullDate = `${
             MONTHS[currentDate.getMonth()]
         } ${currentDate.getDate()}, ${currentDate.getFullYear()}`;
 
-        userEvent.click(getByRole('button', { name: formattedDate }));
+        userEvent.click(getByRole('button', { name: fullDate }));
 
         await waitFor(() => {
-            let expectedMessage;
-            const fullDate = `${currentDate.getDate()}-${
-                MONTHS[currentDate.getMonth()]
-            }-${currentDate.getFullYear()}`;
-            if (currentDate.getDay() === 0) {
-                expectedMessage = `${fullDate} is HOLIDAY(SUNDAY)!`;
-            } else {
-                expectedMessage = `No user status found for muhammadmusab on ${fullDate}!`;
-            }
-
-            expect(getByText(expectedMessage)).toBeInTheDocument();
+            expect(
+                getByText(`${formattedSundayDate} is HOLIDAY(SUNDAY)!`)
+            ).toBeInTheDocument();
         });
     });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
 		'^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
 
 		// Handle CSS imports (without CSS modules)
-		'^.+\\.(css|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
+		'^.+\\.(css|sass|scss)$': '<rootDir>/__mocks__/styleMock.ts',
 
 		/* Handle image imports
     https://jestjs.io/docs/webpack#handling-static-assets */

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -1,11 +1,11 @@
-import { SearchField } from '@/components/Calendar/UserSearchField';
-import Layout from '@/components/Layout';
-import Head from '@/components/head';
-import { MONTHS } from '@/constants/calendar';
-import { processData } from '@/utils/userStatusCalendar';
 import { FC, useState } from 'react';
+import Head from '@/components/head';
+import Layout from '@/components/Layout';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
+import { SearchField } from '@/components/Calendar/UserSearchField';
+import { processData } from '@/utils/userStatusCalendar';
+import { MONTHS } from '@/constants/calendar';
 
 const UserStatusCalendar: FC = () => {
     const [selectedDate, onDateChange] = useState<Date>(new Date());

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -1,11 +1,11 @@
-import { FC, useState } from 'react';
-import Head from '@/components/head';
+import { SearchField } from '@/components/Calendar/UserSearchField';
 import Layout from '@/components/Layout';
+import Head from '@/components/head';
+import { MONTHS } from '@/constants/calendar';
+import { processData } from '@/utils/userStatusCalendar';
+import { FC, useState } from 'react';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
-import { SearchField } from '@/components/Calendar/UserSearchField';
-import { processData } from '@/utils/userStatusCalendar';
-import { MONTHS } from '@/constants/calendar';
 
 const UserStatusCalendar: FC = () => {
     const [selectedDate, onDateChange] = useState<Date>(new Date());
@@ -83,7 +83,7 @@ const UserStatusCalendar: FC = () => {
                     loading={loading}
                 />
                 {selectedUser && (
-                    <div className="calendar">
+                    <div className="calendar" data-testid="react-calendar">
                         <Calendar
                             onChange={onDateChange as any}
                             className="calendar-div"


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 28-02-2024
<!--Developer Name Here-->
Developer Name: @VinayakaHegade 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
#1103 
## Description

This PR adds tests for the calendar page. Currently, we are only able to test predictable statuses, such as "displays holiday message on clicking a Sunday". Other statuses like "active", "idle", and "ooo" cannot be tested with the current implementation. Once the calendar page code is refactored, tests for these remaining statuses will be added.

And change in jest config file is to fix the below issue i was facing.
![config error](https://github.com/Real-Dev-Squad/website-status/assets/88454618/1f2a7ff2-39de-4a0e-a6b7-63556e28abce)


<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->


## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![tests](https://github.com/Real-Dev-Squad/website-status/assets/88454618/26b02f6d-25be-4fa3-a63e-a2127752c301)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
