### PR TITLE
dev to main sync

### DIFF
--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -198,7 +198,9 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
         isExtensionRequestPending?: boolean
     ) {
         return isExtensionRequestPending
-            ? `${TASK_EXTENSION_REQUEST_URL}?taskId=${taskId}`
+            ? `${TASK_EXTENSION_REQUEST_URL}?&q=${encodeURIComponent(
+                  `taskId:${taskId},status:PENDING`
+              )}`
             : null;
     }
 


### PR DESCRIPTION
* bug/extension-req-url: fix extension request url in task details page
---------

<!-- Date Here in dd mmm yyyy-->
Date: 30th March 2024
<!--Developer Name Here-->
Developer Name: Palak Gupta

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
closes #1168
## Description

<!--Description of the changes made in this PR-->
Expected Behavior
On clicking the extension-request show the whole list of the extension-request for that particular task
The list of extension-requests are not in descending order, due to which older Extension Request shows up first.

Current Behavior
On clicking the extension-request icon, show the whole list of the extension-request for that particular task, with status = "PENDING" and sort the data in descending order of creation of the extension request.


### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

https://github.com/Real-Dev-Squad/website-status/assets/61227144/967bcea6-ef34-4d75-92dc-89c7a258b4e4


## Screenshots

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
