### PR TITLE
Fix suggestion selection crash bug

### DIFF
--- a/src/components/tasks/TaskSearchDev/TaskSearchDev.tsx
+++ b/src/components/tasks/TaskSearchDev/TaskSearchDev.tsx
@@ -190,6 +190,8 @@ const TaskSearchDev = ({
     const onSuggestionSelected = (
         idx = activeFilterSuggestionDropdownIndex
     ) => {
+        if (!filterSuggestions?.[idx]) return;
+
         if (onEditSelectedFilterIndex === false) {
             const optionDetails = filterSuggestions[idx];
             if (optionDetails) {


### PR DESCRIPTION
## Description

Fix crash on editing field, before suggestions could appear.
Exact steps:
- Enter `status:in-progress` field 
- Do some small change in the field `in-progress`
- Press enter before suggestion could pop up


### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [x] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Before Fix</summary>

[Screencast from 27-05-24 06:15:27 PM IST.webm](https://github.com/Real-Dev-Squad/website-status/assets/63191499/fca6f554-70cb-4c7c-a008-d33b20c67a82)



</details>

<details>
<summary>After Fix</summary>

https://github.com/Real-Dev-Squad/website-status/assets/63191499/1609de23-9664-458d-b726-94111d28e763


</details>


<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
