### PR TITLE
fix alert message on issues page

### DIFF
--- a/src/components/Modal/modal.module.scss
+++ b/src/components/Modal/modal.module.scss
@@ -10,7 +10,7 @@
     }
 }
 .modalOverlay {
-    z-index: 9999;
+    z-index: 9998;
     width: 100%;
     height: 100%;
     position: fixed;


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 10/09/24
<!--Developer Name Here-->
Developer Name: Sameer Supe

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #1255 
## Description

<!--Description of the changes made in this PR-->
Fixes alert box which pops behind modal overlay. Conflict comes in from similar z-index value(9999) of modal overlay and react-toastify component.
### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [x] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

https://github.com/user-attachments/assets/bcbbf853-bf1d-4b74-8b7e-6d69ae525b07


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![status-tests](https://github.com/user-attachments/assets/da19a9d7-397b-4a12-b657-f2b53ebc3aa2)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
