### PR TITLE
Fixes date picker alignment and date value not showing up while editing on task details page

### DIFF
--- a/__mocks__/handlers/task-details.handler.ts
+++ b/__mocks__/handlers/task-details.handler.ts
@@ -1,3 +1,4 @@
+import { TASKS_URL } from '@/constants/url';
 import { rest } from 'msw';
 const URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -135,4 +136,18 @@ const failedTaskDependencyDetails = rest.get(
     }
 );
 
-export { taskDetailsHandler, failedTaskDependencyDetails };
+const failedToUpdateTaskDetails = rest.patch(
+    `${TASKS_URL}/6KhcLU3yr45dzjQIVm0J`,
+    (req, res, ctx) => {
+        return res(
+            ctx.status(500),
+            ctx.json({ message: 'Failed to update the task details' })
+        );
+    }
+);
+
+export {
+    taskDetailsHandler,
+    failedTaskDependencyDetails,
+    failedToUpdateTaskDetails,
+};

--- a/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
@@ -20,6 +20,10 @@ jest.mock('@/hooks/useUserData', () => {
 const mockHandleEditedTaskDetails = jest.fn();
 
 describe('TaskDates Component', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
     it('should render input field for End On date when in editing mode', () => {
         render(
             <Provider store={store()}>
@@ -84,7 +88,7 @@ describe('TaskDates Component', () => {
                 <TaskDates
                     isEditing={true}
                     startedOn="2024-03-30T11:20:00Z"
-                    endsOn={1700000000}
+                    endsOn={null}
                     setEditedTaskDetails={mockHandleEditedTaskDetails}
                     isExtensionRequestPending={false}
                     taskId="1"

--- a/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import { TaskDates } from '@/components/taskDetails/TaskDates';
 import { store } from '@/app/store';
+import { renderWithRouter } from '@/test_utils/createMockRouter';
 
 jest.mock('@/hooks/useUserData', () => {
     return () => ({
@@ -25,7 +26,7 @@ describe('TaskDates Component', () => {
     });
 
     it('should render input field for End On date when in editing mode', () => {
-        render(
+        renderWithRouter(
             <Provider store={store()}>
                 <TaskDates
                     isEditing={true}
@@ -47,7 +48,7 @@ describe('TaskDates Component', () => {
     });
 
     it('should not render input field for End On date when not in editing mode', () => {
-        render(
+        renderWithRouter(
             <Provider store={store()}>
                 <TaskDates
                     isEditing={false}
@@ -65,7 +66,7 @@ describe('TaskDates Component', () => {
     });
 
     it('should display an extension icon, when isExtensionRequestPending is true', () => {
-        render(
+        renderWithRouter(
             <Provider store={store()}>
                 <TaskDates
                     isEditing={true}
@@ -83,7 +84,7 @@ describe('TaskDates Component', () => {
     });
 
     it('should not update the input value if invalid date is entered', () => {
-        render(
+        renderWithRouter(
             <Provider store={store()}>
                 <TaskDates
                     isEditing={true}
@@ -105,7 +106,7 @@ describe('TaskDates Component', () => {
     });
 
     it('should render correctly with admin role', () => {
-        render(
+        renderWithRouter(
             <Provider store={store()}>
                 <TaskDates
                     isEditing={true}
@@ -136,7 +137,7 @@ describe('TaskDates Component', () => {
             });
         });
 
-        render(
+        renderWithRouter(
             <Provider store={store()}>
                 <TaskDates
                     isEditing={true}
@@ -154,7 +155,7 @@ describe('TaskDates Component', () => {
     });
 
     it('should render the correct date when endsOn is null', () => {
-        render(
+        renderWithRouter(
             <Provider store={store()}>
                 <TaskDates
                     isEditing={true}

--- a/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
@@ -41,4 +41,131 @@ describe('TaskDates Component', () => {
         fireEvent.blur(input);
         expect(input.value).toBe('2024-04-15');
     });
+
+    it('should not render input field for End On date when not in editing mode', () => {
+        render(
+            <Provider store={store()}>
+                <TaskDates
+                    isEditing={false}
+                    startedOn="2024-03-30T11:20:00Z"
+                    endsOn={1700000000}
+                    setEditedTaskDetails={mockHandleEditedTaskDetails}
+                    isExtensionRequestPending={false}
+                    taskId="1"
+                />
+            </Provider>
+        );
+
+        const input = screen.queryByTestId('endsOnTaskDetails');
+        expect(input).toBeNull();
+    });
+
+    it('should display an extension icon, when isExtensionRequestPending is true', () => {
+        render(
+            <Provider store={store()}>
+                <TaskDates
+                    isEditing={true}
+                    startedOn="2024-03-30T11:20:00Z"
+                    endsOn={1700000000}
+                    setEditedTaskDetails={mockHandleEditedTaskDetails}
+                    isExtensionRequestPending={true}
+                    taskId="1"
+                />
+            </Provider>
+        );
+
+        const extensionIcon = screen.getByTestId('extension-request-icon');
+        expect(extensionIcon).toBeInTheDocument();
+    });
+
+    it('should not update the input value if invalid date is entered', () => {
+        render(
+            <Provider store={store()}>
+                <TaskDates
+                    isEditing={true}
+                    startedOn="2024-03-30T11:20:00Z"
+                    endsOn={1700000000}
+                    setEditedTaskDetails={mockHandleEditedTaskDetails}
+                    isExtensionRequestPending={false}
+                    taskId="1"
+                />
+            </Provider>
+        );
+
+        const input = screen.getByTestId(
+            'endsOnTaskDetails'
+        ) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'invalid-date' } });
+        fireEvent.blur(input);
+        expect(input.value).toBe('');
+    });
+
+    it('should render correctly with admin role', () => {
+        render(
+            <Provider store={store()}>
+                <TaskDates
+                    isEditing={true}
+                    startedOn="2024-03-30T11:20:00Z"
+                    endsOn={1700000000}
+                    setEditedTaskDetails={mockHandleEditedTaskDetails}
+                    isExtensionRequestPending={false}
+                    taskId="1"
+                />
+            </Provider>
+        );
+
+        const input = screen.getByTestId('endsOnTaskDetails');
+        expect(input).toBeInTheDocument();
+    });
+
+    it('should render correctly with non-admin role', () => {
+        jest.mock('@/hooks/useUserData', () => {
+            return () => ({
+                data: {
+                    roles: {
+                        admin: false,
+                        super_user: true,
+                    },
+                },
+                isUserAuthorized: true,
+                isSuccess: true,
+            });
+        });
+
+        render(
+            <Provider store={store()}>
+                <TaskDates
+                    isEditing={true}
+                    startedOn="2024-03-30T11:20:00Z"
+                    endsOn={1700000000}
+                    setEditedTaskDetails={mockHandleEditedTaskDetails}
+                    isExtensionRequestPending={false}
+                    taskId="1"
+                />
+            </Provider>
+        );
+
+        const input = screen.getByTestId('endsOnTaskDetails');
+        expect(input).toBeInTheDocument();
+    });
+
+    it('should render the correct date when endsOn is null', () => {
+        render(
+            <Provider store={store()}>
+                <TaskDates
+                    isEditing={true}
+                    startedOn="2024-03-30T11:20:00Z"
+                    endsOn={null}
+                    setEditedTaskDetails={mockHandleEditedTaskDetails}
+                    isExtensionRequestPending={false}
+                    taskId="1"
+                />
+            </Provider>
+        );
+
+        const input = screen.getByTestId(
+            'endsOnTaskDetails'
+        ) as HTMLInputElement;
+        expect(input.value).toBe('');
+    });
 });

--- a/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
@@ -105,7 +105,7 @@ describe('TaskDates Component', () => {
         expect(input.value).toBe('');
     });
 
-    it('should render correctly with admin role', () => {
+    it('should render input element correctly with admin role', () => {
         renderWithRouter(
             <Provider store={store()}>
                 <TaskDates
@@ -123,7 +123,7 @@ describe('TaskDates Component', () => {
         expect(input).toBeInTheDocument();
     });
 
-    it('should render correctly with non-admin role', () => {
+    it('should render input element correctly with non-admin role', () => {
         jest.mock('@/hooks/useUserData', () => {
             return () => ({
                 data: {

--- a/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDates.test.tsx
@@ -1,28 +1,44 @@
+import React from 'react';
+import { Provider } from 'react-redux';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TaskDates } from '@/components/taskDetails/TaskDates';
+import { store } from '@/app/store';
 
-const mockSetNewEndOnDate = jest.fn();
-const mockHandleBlurOfEndsOn = jest.fn();
+jest.mock('@/hooks/useUserData', () => {
+    return () => ({
+        data: {
+            roles: {
+                admin: true,
+                super_user: false,
+            },
+        },
+        isUserAuthorized: true,
+        isSuccess: true,
+    });
+});
+
+const mockHandleEditedTaskDetails = jest.fn();
 
 describe('TaskDates Component', () => {
     it('should render input field for End On date when in editing mode', () => {
         render(
-            <TaskDates
-                isEditing={true}
-                isUserAuthorized={true}
-                startedOn="2024-03-30T11:20:00Z"
-                endsOn={1700000000}
-                newEndOnDate="2024-03-30"
-                setNewEndOnDate={mockSetNewEndOnDate}
-                handleBlurOfEndsOn={mockHandleBlurOfEndsOn}
-                isExtensionRequestPending={false}
-                taskId="1"
-            />
+            <Provider store={store()}>
+                <TaskDates
+                    isEditing={true}
+                    startedOn="2024-03-30T11:20:00Z"
+                    endsOn={1700000000}
+                    setEditedTaskDetails={mockHandleEditedTaskDetails}
+                    isExtensionRequestPending={false}
+                    taskId="1"
+                />
+            </Provider>
         );
 
-        const input = screen.getByTestId('endsOnTaskDetails');
-        expect(input).toBeInTheDocument();
+        const input = screen.getByTestId(
+            'endsOnTaskDetails'
+        ) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '2024-04-15' } });
         fireEvent.blur(input);
-        expect(mockHandleBlurOfEndsOn).toHaveBeenCalled();
+        expect(input.value).toBe('2024-04-15');
     });
 });

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -305,13 +305,27 @@ test('should call onSave and reset state when clicked', async () => {
     await waitFor(() => {
         const editButton = screen.getByRole('button', { name: 'Edit' });
         fireEvent.click(editButton);
+        const input = screen.getByTestId(
+            'endsOnTaskDetails'
+        ) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: '2024-04-15' } });
+        fireEvent.blur(input);
+        expect(input.value).toBe('2024-04-15');
+        const saveButton = screen.getByRole('button', { name: 'Save' });
+        fireEvent.click(saveButton);
     });
 
     await waitFor(() => {
-        const saveButton = screen.getByRole('button', { name: 'Save' });
-        fireEvent.click(saveButton);
-        const editButton = screen.getByRole('button', { name: 'Edit' });
-        expect(editButton).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: 'Saving...' })
+        ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+        const editButtonAfterSave = screen.getByRole('button', {
+            name: 'Edit',
+        });
+        expect(editButtonAfterSave).toBeInTheDocument();
     });
 });
 
@@ -333,10 +347,10 @@ test('should update the title and description with the new values', async () => 
     fireEvent.change(textareaElement, {
         target: { name: 'title', value: 'New Title' },
     });
-    await waitFor(async () => {
+    waitFor(() => {
         const saveButton = screen.getByRole('button', { name: 'Save' });
         fireEvent.click(saveButton);
-        expect(await screen.findByText(/Successfully saved/i)).not.toBeNull();
+        expect(screen.findByText(/Successfully saved/i)).not.toBeNull();
     });
 });
 test('should not update the title and description with the same values', async () => {

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -57,6 +57,8 @@ jest.mock('@/hooks/useUserData', () => {
 });
 
 const mockNavigateToUpdateProgressPage = jest.fn();
+const mockHandleEditedTaskDetails = jest.fn();
+
 describe('TaskDetails Page', () => {
     it('Should render title', async () => {
         const { getByText } = renderWithRouter(
@@ -695,5 +697,31 @@ describe('Details component', () => {
             console.error('Error occurred during tooltip rendering:', error);
             throw error;
         }
+    });
+
+    it('Renders an input with prefilled data provided, when isEditing is true', () => {
+        const task = {
+            id: 'L1SDW6O835o0EI8ZmvRc',
+            endedOn: 1700000000,
+        };
+        const formattedEndsOn = convertTimeStamp(task.endedOn);
+        const expectedDate = new Date(formattedEndsOn).toLocaleDateString(
+            'en-CA'
+        );
+
+        renderWithRouter(
+            <Details
+                detailType={ENDS_ON}
+                value={formattedEndsOn}
+                isEditing
+                setEditedTaskDetails={mockHandleEditedTaskDetails}
+            />
+        );
+
+        const input = screen.getByTestId(
+            'endsOnTaskDetails'
+        ) as HTMLInputElement;
+
+        expect(input.defaultValue).toBe(expectedDate);
     });
 });

--- a/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskDetails.test.tsx
@@ -367,11 +367,12 @@ test('should update the title and description with the new values', async () => 
     fireEvent.change(textareaElement, {
         target: { name: 'title', value: 'New Title' },
     });
-    waitFor(() => {
-        const saveButton = screen.getByRole('button', { name: 'Save' });
-        fireEvent.click(saveButton);
-        expect(screen.findByText(/Successfully saved/i)).not.toBeNull();
+
+    const saveButton = await screen.findByRole('button', {
+        name: 'Save',
     });
+    fireEvent.click(saveButton);
+    expect(screen.findByText(/Successfully saved/i)).not.toBeNull();
 });
 test('should not update the title and description with the same values', async () => {
     server.use(...taskDetailsHandler);

--- a/__tests__/Unit/Components/Tasks/TaskHeader.test.tsx
+++ b/__tests__/Unit/Components/Tasks/TaskHeader.test.tsx
@@ -1,13 +1,12 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { TaskHeader } from '@/components/taskDetails/TaskHeader';
-import { ButtonProps } from '@/interfaces/taskDetails.type';
 
 const mockSetIsEditing = jest.fn();
 const mockOnSave = jest.fn();
 const mockOnCancel = jest.fn();
 const mockHandleChange = jest.fn();
 
-const renderTaskHeader = (isEditing = false) => {
+const renderTaskHeader = (isEditing = false, loading = false) => {
     return render(
         <TaskHeader
             isEditing={isEditing}
@@ -17,6 +16,7 @@ const renderTaskHeader = (isEditing = false) => {
             title="Test Title"
             handleChange={mockHandleChange}
             isUserAuthorized={true}
+            loading={loading}
         />
     );
 };
@@ -51,6 +51,16 @@ describe('TaskHeader Component', () => {
         renderTaskHeader(true);
         fireEvent.click(screen.getByRole('button', { name: 'Save' }));
         expect(mockOnSave).toHaveBeenCalled();
+    });
+
+    it('should show saving... loader when loader is true', () => {
+        renderTaskHeader(true);
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+        expect(mockOnSave).toHaveBeenCalled();
+        renderTaskHeader(true, true);
+        expect(screen.getByRole('button', { name: 'Saving...' }));
+        renderTaskHeader(false, false);
+        expect(screen.getByRole('button', { name: 'Edit' }));
     });
 
     it('should calls onCancel when Cancel button is clicked', () => {

--- a/__tests__/Utils/isValidDate.test.ts
+++ b/__tests__/Utils/isValidDate.test.ts
@@ -1,0 +1,23 @@
+import { isValidDate } from '@/utils/isValidDate';
+
+describe('isValidDate', () => {
+    it('should return true for valid dates in "YYYY-MM-DD" format', () => {
+        expect(isValidDate('2023-10-05')).toBe(true);
+        expect(isValidDate('1999-12-31')).toBe(true);
+        expect(isValidDate('2000-02-29')).toBe(true);
+    });
+
+    it('should return false for dates with an invalid format', () => {
+        expect(isValidDate('23-10-05')).toBe(false);
+        expect(isValidDate('2023-1-5')).toBe(false);
+        expect(isValidDate('2023/10/05')).toBe(false);
+        expect(isValidDate('05-10-2023')).toBe(false);
+        expect(isValidDate('')).toBe(false);
+    });
+
+    it('should return false for invalid date strings', () => {
+        expect(isValidDate('not-a-date')).toBe(false);
+        expect(isValidDate('2023-10-')).toBe(false);
+        expect(isValidDate('2023-XX-05')).toBe(false);
+    });
+});

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -26,12 +26,14 @@ const DetailsContent: FC<DetailsContentProps> = ({
     renderedValue,
     getRelativeTime,
 }) => {
+    const displayValue = renderedValue || value;
+
     return (
         <span
             className={styles.detailValue}
             style={{ color: color ?? 'black' }}
         >
-            {isGitHubLink && value ? (
+            {isGitHubLink && value && gitHubIssueLink ? (
                 <a
                     className={styles.gitLink}
                     href={gitHubIssueLink}
@@ -40,9 +42,9 @@ const DetailsContent: FC<DetailsContentProps> = ({
                     aria-label="Open GitHub Issue"
                     title={value}
                 >
-                    {isGitHubLink ? `${extractRepoName(value)}` : value}
+                    {extractRepoName(value)}
                 </a>
-            ) : isTimeDetail ? (
+            ) : isTimeDetail && value ? (
                 <Tooltip
                     content={formatDate(value)}
                     tooltipPosition={{
@@ -53,7 +55,7 @@ const DetailsContent: FC<DetailsContentProps> = ({
                     {tooltipActive ? formatDate(value) : getRelativeTime(value)}
                 </Tooltip>
             ) : (
-                renderedValue
+                displayValue
             )}
         </span>
     );

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -68,8 +68,8 @@ const Details: FC<TaskDetailsProps> = (props) => {
     const { isUserAuthorized } = useUserData();
 
     useEffect(() => {
-        if (!isEditing) setNewEndOnDate('');
-    }, [isEditing]);
+        if (!isEditing && newEndOnDate !== '') setNewEndOnDate('');
+    }, [isEditing, newEndOnDate]);
 
     const handleBlurOfEndsOn = () => {
         const endsOn = new Date(`${newEndOnDate}`).getTime() / 1000;

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -72,13 +72,18 @@ const Details: FC<TaskDetailsProps> = (props) => {
     }, [isEditing]);
 
     const handleBlurOfEndsOn = () => {
-        const endsOn = new Date(`${newEndOnDate}`).getTime() / 1000;
+        const isDateValid = !isNaN(new Date(`${newEndOnDate}`).getTime());
+        const endsOn = isDateValid
+            ? new Date(`${newEndOnDate}`).getTime() / 1000
+            : null;
 
-        if (endsOn > 0) {
+        if (endsOn && endsOn > 0) {
             setEditedTaskDetails?.((prev) => ({
                 ...prev,
                 endsOn,
             }));
+        } else {
+            console.error('Invalid date provided', newEndOnDate);
         }
     };
 

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -73,8 +73,16 @@ const Details: FC<TaskDetailsProps> = (props) => {
         if (!isEditing) setNewEndOnDate('');
     }, [isEditing]);
 
+    const isValidDate = (dateString: string) => {
+        // Validating the "YYYY-MM-DD" format strictly
+        const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+        return (
+            dateRegex.test(dateString) && !isNaN(new Date(dateString).getTime())
+        );
+    };
+
     const handleBlurOfEndsOn = () => {
-        const isDateValid = !isNaN(new Date(`${newEndOnDate}`).getTime());
+        const isDateValid = isValidDate(newEndOnDate);
         const endsOn = isDateValid
             ? new Date(`${newEndOnDate}`).getTime() / 1000
             : null;

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -68,8 +68,8 @@ const Details: FC<TaskDetailsProps> = (props) => {
     const { isUserAuthorized } = useUserData();
 
     useEffect(() => {
-        if (!isEditing && newEndOnDate !== '') setNewEndOnDate('');
-    }, [isEditing, newEndOnDate]);
+        if (!isEditing) setNewEndOnDate('');
+    }, [isEditing]);
 
     const handleBlurOfEndsOn = () => {
         const endsOn = new Date(`${newEndOnDate}`).getTime() / 1000;

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/interfaces/taskDetails.type';
 import useUserData from '@/hooks/useUserData';
 import { STARTED_ON, ENDS_ON } from '@/constants/constants';
+import { isValidDate } from '@/utils/isValidDate';
 
 type StringNumberOrUndefined = string | number | undefined;
 
@@ -28,12 +29,12 @@ const DetailsContent: FC<DetailsContentProps> = ({
 }) => {
     const displayValue = renderedValue || value;
 
-    return (
-        <span
-            className={styles.detailValue}
-            style={{ color: color ?? 'black' }}
-        >
-            {isGitHubLink && value && gitHubIssueLink ? (
+    if (isGitHubLink && value && gitHubIssueLink) {
+        return (
+            <span
+                className={styles.detailValue}
+                style={{ color: color ?? 'black' }}
+            >
                 <a
                     className={styles.gitLink}
                     href={gitHubIssueLink}
@@ -44,7 +45,16 @@ const DetailsContent: FC<DetailsContentProps> = ({
                 >
                     {extractRepoName(value)}
                 </a>
-            ) : isTimeDetail && value ? (
+            </span>
+        );
+    }
+
+    if (isTimeDetail && value) {
+        return (
+            <span
+                className={styles.detailValue}
+                style={{ color: color ?? 'black' }}
+            >
                 <Tooltip
                     content={formatDate(value)}
                     tooltipPosition={{
@@ -54,9 +64,16 @@ const DetailsContent: FC<DetailsContentProps> = ({
                 >
                     {tooltipActive ? formatDate(value) : getRelativeTime(value)}
                 </Tooltip>
-            ) : (
-                displayValue
-            )}
+            </span>
+        );
+    }
+
+    return (
+        <span
+            className={styles.detailValue}
+            style={{ color: color ?? 'black' }}
+        >
+            {displayValue}
         </span>
     );
 };
@@ -73,15 +90,7 @@ const Details: FC<TaskDetailsProps> = (props) => {
         if (!isEditing) setNewEndOnDate('');
     }, [isEditing]);
 
-    const isValidDate = (dateString: string) => {
-        // Validating the "YYYY-MM-DD" format strictly
-        const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-        return (
-            dateRegex.test(dateString) && !isNaN(new Date(dateString).getTime())
-        );
-    };
-
-    const handleBlurOfEndsOn = () => {
+    const handleEndsOnBlur = () => {
         const isDateValid = isValidDate(newEndOnDate);
         const endsOn = isDateValid
             ? new Date(`${newEndOnDate}`).getTime() / 1000
@@ -155,7 +164,7 @@ const Details: FC<TaskDetailsProps> = (props) => {
                     type="date"
                     name="endsOn"
                     onChange={(e) => setNewEndOnDate(e.target.value)}
-                    onBlur={handleBlurOfEndsOn}
+                    onBlur={handleEndsOnBlur}
                     value={
                         newEndOnDate ||
                         new Date(value as string).toLocaleDateString('en-CA')

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 import moment from 'moment';
 import { FaReceipt } from 'react-icons/fa6';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import Tooltip from '@/components/common/Tooltip/Tooltip';
 import setColor from './taskPriorityColors';
 import extractRepoName from '@/utils/extractRepoName';
@@ -85,6 +86,8 @@ const Details: FC<TaskDetailsProps> = (props) => {
     const gitHubIssueLink = isGitHubLink ? value : undefined;
     const [newEndOnDate, setNewEndOnDate] = useState('');
     const { isUserAuthorized } = useUserData();
+    const router = useRouter();
+    const isDevFlagEnabled = router.query.dev === 'true';
 
     useEffect(() => {
         if (!isEditing) setNewEndOnDate('');
@@ -154,6 +157,9 @@ const Details: FC<TaskDetailsProps> = (props) => {
             : detailType;
 
     const renderedValue = value ?? 'N/A';
+    const dateValue =
+        newEndOnDate || new Date(value as string).toLocaleDateString('en-CA');
+    const finalDateValue = isDevFlagEnabled ? dateValue : newEndOnDate;
 
     return (
         <div className={styles.detailsContainer}>
@@ -165,10 +171,7 @@ const Details: FC<TaskDetailsProps> = (props) => {
                     name="endsOn"
                     onChange={(e) => setNewEndOnDate(e.target.value)}
                     onBlur={handleEndsOnBlur}
-                    value={
-                        newEndOnDate ||
-                        new Date(value as string).toLocaleDateString('en-CA')
-                    }
+                    value={finalDateValue}
                     className={styles.inputField}
                 />
             ) : (

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -6,11 +6,58 @@ import Tooltip from '@/components/common/Tooltip/Tooltip';
 import setColor from './taskPriorityColors';
 import extractRepoName from '@/utils/extractRepoName';
 import styles from './task-details.module.scss';
-import { TaskDetailsProps } from '@/interfaces/taskDetails.type';
+import {
+    DetailsContentProps,
+    TaskDetailsProps,
+} from '@/interfaces/taskDetails.type';
 import useUserData from '@/hooks/useUserData';
 import { STARTED_ON, ENDS_ON } from '@/constants/constants';
 
 type StringNumberOrUndefined = string | number | undefined;
+
+const DetailsContent: FC<DetailsContentProps> = ({
+    color,
+    isGitHubLink,
+    value,
+    gitHubIssueLink,
+    isTimeDetail,
+    formatDate,
+    tooltipActive,
+    renderedValue,
+    getRelativeTime,
+}) => {
+    return (
+        <span
+            className={styles.detailValue}
+            style={{ color: color ?? 'black' }}
+        >
+            {isGitHubLink && value ? (
+                <a
+                    className={styles.gitLink}
+                    href={gitHubIssueLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Open GitHub Issue"
+                    title={value}
+                >
+                    {isGitHubLink ? `${extractRepoName(value)}` : value}
+                </a>
+            ) : isTimeDetail ? (
+                <Tooltip
+                    content={formatDate(value)}
+                    tooltipPosition={{
+                        top: '-3.6rem',
+                        right: '-4.5rem',
+                    }}
+                >
+                    {tooltipActive ? formatDate(value) : getRelativeTime(value)}
+                </Tooltip>
+            ) : (
+                renderedValue
+            )}
+        </span>
+    );
+};
 
 const Details: FC<TaskDetailsProps> = (props) => {
     const { detailType, value, url, isEditing, setEditedTaskDetails } = props;
@@ -101,37 +148,17 @@ const Details: FC<TaskDetailsProps> = (props) => {
                     className={styles.inputField}
                 />
             ) : (
-                <span
-                    className={styles.detailValue}
-                    style={{ color: color ?? 'black' }}
-                >
-                    {isGitHubLink && value ? (
-                        <a
-                            className={styles.gitLink}
-                            href={gitHubIssueLink}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            aria-label="Open GitHub Issue"
-                            title={value}
-                        >
-                            {isGitHubLink ? `${extractRepoName(value)}` : value}
-                        </a>
-                    ) : isTimeDetail ? (
-                        <Tooltip
-                            content={formatDate(value)}
-                            tooltipPosition={{
-                                top: '-3.6rem',
-                                right: '-4.5rem',
-                            }}
-                        >
-                            {tooltipActive
-                                ? formatDate(value)
-                                : getRelativeTime(value)}
-                        </Tooltip>
-                    ) : (
-                        renderedValue
-                    )}
-                </span>
+                <DetailsContent
+                    color={color}
+                    isGitHubLink={isGitHubLink}
+                    value={value}
+                    gitHubIssueLink={gitHubIssueLink}
+                    isTimeDetail={isTimeDetail}
+                    formatDate={formatDate}
+                    tooltipActive={tooltipActive}
+                    renderedValue={renderedValue}
+                    getRelativeTime={getRelativeTime}
+                />
             )}
             <span>
                 {detailType === ENDS_ON && url && (

--- a/src/components/taskDetails/Details.tsx
+++ b/src/components/taskDetails/Details.tsx
@@ -89,7 +89,7 @@ const Details: FC<TaskDetailsProps> = (props) => {
             <span className={styles.detailType}>{formattedDetailType}:</span>
             {isEditing && isUserAuthorized ? (
                 <input
-                    id="endsOnTaskDetails"
+                    data-testid="endsOnTaskDetails"
                     type="date"
                     name="endsOn"
                     onChange={(e) => setNewEndOnDate(e.target.value)}
@@ -98,7 +98,6 @@ const Details: FC<TaskDetailsProps> = (props) => {
                         newEndOnDate ||
                         new Date(value as string).toLocaleDateString('en-CA')
                     }
-                    data-testid="endsOnTaskDetails"
                     className={styles.inputField}
                 />
             ) : (

--- a/src/components/taskDetails/TaskDates.tsx
+++ b/src/components/taskDetails/TaskDates.tsx
@@ -3,31 +3,31 @@ import Details from './Details';
 import styles from './task-details.module.scss';
 import { TASK_EXTENSION_REQUEST_URL } from '@/constants/url';
 import convertTimeStamp from '@/helperFunctions/convertTimeStamp';
+import task from '@/interfaces/task.type';
 
 interface TaskDatesProps {
     isEditing: boolean;
-    isUserAuthorized: boolean;
     startedOn: string;
     endsOn: number;
-    newEndOnDate: string;
-    setNewEndOnDate: (date: string) => void;
-    handleBlurOfEndsOn: () => void;
     isExtensionRequestPending: boolean;
     taskId: string;
+    setEditedTaskDetails: React.Dispatch<React.SetStateAction<task>>;
 }
 
 export const TaskDates: React.FC<TaskDatesProps> = ({
     isEditing,
-    isUserAuthorized,
     startedOn,
     endsOn,
-    newEndOnDate,
-    setNewEndOnDate,
-    handleBlurOfEndsOn,
     isExtensionRequestPending,
     taskId,
+    setEditedTaskDetails,
 }) => {
     const formattedEndsOn = endsOn ? convertTimeStamp(endsOn) : 'TBD';
+    const url = isExtensionRequestPending
+        ? `${TASK_EXTENSION_REQUEST_URL}?&q=${encodeURIComponent(
+              `taskId:${taskId},status:PENDING`
+          )}`
+        : null;
 
     return (
         <>
@@ -35,30 +35,13 @@ export const TaskDates: React.FC<TaskDatesProps> = ({
                 <Details detailType="Started On" value={startedOn} />
             </div>
             <div className={styles.inputContainer}>
-                {isExtensionRequestPending && (
-                    <Details
-                        detailType="Ends On"
-                        value={formattedEndsOn}
-                        url={`${TASK_EXTENSION_REQUEST_URL}?&q=${encodeURIComponent(
-                            `taskId:${taskId},status:PENDING`
-                        )}`}
-                    />
-                )}
-                {!isExtensionRequestPending && (
-                    <Details detailType="Ends On" value={formattedEndsOn} />
-                )}
-                {isEditing && isUserAuthorized && (
-                    <input
-                        id="endsOnTaskDetails"
-                        type="date"
-                        name="endsOn"
-                        onChange={(e) => setNewEndOnDate(e.target.value)}
-                        onBlur={handleBlurOfEndsOn}
-                        value={newEndOnDate}
-                        data-testid="endsOnTaskDetails"
-                        className={styles.inputField}
-                    />
-                )}
+                <Details
+                    detailType="Ends On"
+                    value={formattedEndsOn}
+                    url={url}
+                    isEditing={isEditing}
+                    setEditedTaskDetails={setEditedTaskDetails}
+                />
             </div>
         </>
     );

--- a/src/components/taskDetails/TaskDates.tsx
+++ b/src/components/taskDetails/TaskDates.tsx
@@ -9,7 +9,7 @@ import task from '@/interfaces/task.type';
 interface TaskDatesProps {
     isEditing: boolean;
     startedOn: string;
-    endsOn: number;
+    endsOn: number | null;
     isExtensionRequestPending: boolean;
     taskId: string;
     setEditedTaskDetails: React.Dispatch<React.SetStateAction<task>>;

--- a/src/components/taskDetails/TaskHeader.tsx
+++ b/src/components/taskDetails/TaskHeader.tsx
@@ -10,6 +10,7 @@ interface TaskHeaderProps {
     title: string;
     handleChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
     isUserAuthorized: boolean;
+    loading?: boolean;
 }
 
 export const TaskHeader: React.FC<TaskHeaderProps> = ({
@@ -20,6 +21,7 @@ export const TaskHeader: React.FC<TaskHeaderProps> = ({
     title,
     handleChange,
     isUserAuthorized,
+    loading,
 }) => {
     if (isEditing) {
         return (
@@ -33,7 +35,11 @@ export const TaskHeader: React.FC<TaskHeaderProps> = ({
                 />
                 <div className={styles.editMode}>
                     <Button buttonName="Cancel" clickHandler={onCancel} />
-                    <Button buttonName="Save" clickHandler={onSave} />
+                    <Button
+                        buttonName={loading ? 'Saving...' : 'Save'}
+                        disabled={loading}
+                        clickHandler={onSave}
+                    />
                 </div>
             </div>
         );

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -201,10 +201,6 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
         return timestamp ? convertTimeStamp(parseInt(timestamp, 10)) : 'N/A';
     }
 
-    function getEndsOn(timestamp: number | undefined) {
-        return timestamp ? convertTimeStamp(timestamp) : 'TBD';
-    }
-
     const shouldRenderParentContainer = () => !isLoading && !isError && data;
 
     const { data: progressData } = useGetProgressDetailsQuery({

--- a/src/components/taskDetails/index.tsx
+++ b/src/components/taskDetails/index.tsx
@@ -92,6 +92,8 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
     );
     const inputRef = useRef<HTMLInputElement>(null);
     const [showSuggestion, setShowSuggestion] = useState<boolean>(false);
+    const isDevFlagEnabled = router.query.dev === 'true';
+
     const handleAssignment = (e: React.ChangeEvent<HTMLInputElement>) => {
         setAssigneeName(e.target.value);
         setShowSuggestion(Boolean(e.target.value));
@@ -139,6 +141,7 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
         setEditedTaskDetails(taskDetailsData);
     }
     async function onSave() {
+        !isDevFlagEnabled && setIsEditing(false);
         const updatedFields: Partial<taskDetailsDataType['taskData']> = {};
         for (const key in editedTaskDetails) {
             if (
@@ -161,7 +164,7 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
             return;
         }
 
-        setLoading(true);
+        isDevFlagEnabled && setLoading(true);
         await updateTaskDetails({
             editedDetails: updatedFields,
             taskID,
@@ -170,8 +173,8 @@ const TaskDetails: FC<Props> = ({ taskID }) => {
             .then(() => toast(SUCCESS, 'Successfully saved'))
             .catch((error) => toast(ERROR, error.data.message))
             .finally(() => {
-                setIsEditing(false);
-                setLoading(false);
+                isDevFlagEnabled && setIsEditing(false);
+                isDevFlagEnabled && setLoading(false);
             });
     }
 

--- a/src/components/taskDetails/task-details.module.scss
+++ b/src/components/taskDetails/task-details.module.scss
@@ -36,6 +36,12 @@
         background-color: $theme-primary;
         color: $white;
     }
+
+    &:disabled {
+        background-color: $light-gray;
+        color: $black;
+        cursor: not-allowed;
+    }
 }
 
 .gitLink {
@@ -182,6 +188,7 @@
     padding: 0.5rem;
     border: 1px solid #ccc;
     border-radius: 0.25rem;
+    margin-top: -10px;
 }
 
 .assigneeSuggestionInput {

--- a/src/interfaces/taskDetails.type.ts
+++ b/src/interfaces/taskDetails.type.ts
@@ -11,6 +11,7 @@ export type ButtonProps = {
     clickHandler: (value: boolean) => void;
     value?: boolean;
     className?: string;
+    disabled?: boolean;
 };
 export type TextAreaProps = {
     name: string;
@@ -32,6 +33,8 @@ export type TaskDetailsProps = {
     detailType: string;
     value?: string;
     url?: string | null;
+    isEditing?: boolean;
+    setEditedTaskDetails?: React.Dispatch<React.SetStateAction<task>>;
 };
 export type DependencyItem =
     | PromiseFulfilledResult<{

--- a/src/interfaces/taskDetails.type.ts
+++ b/src/interfaces/taskDetails.type.ts
@@ -36,6 +36,17 @@ export type TaskDetailsProps = {
     isEditing?: boolean;
     setEditedTaskDetails?: React.Dispatch<React.SetStateAction<task>>;
 };
+export type DetailsContentProps = {
+    color: string | undefined;
+    isGitHubLink: boolean;
+    value: string | undefined;
+    gitHubIssueLink: string | undefined;
+    isTimeDetail: boolean;
+    formatDate: (timestamp: string | number | undefined) => string;
+    tooltipActive: boolean;
+    renderedValue: string;
+    getRelativeTime: (timestamp: string | number | undefined) => string;
+};
 export type DependencyItem =
     | PromiseFulfilledResult<{
           title: string | undefined;

--- a/src/utils/isValidDate.ts
+++ b/src/utils/isValidDate.ts
@@ -1,0 +1,5 @@
+export const isValidDate = (dateString: string) => {
+    // Validating the "YYYY-MM-DD" format strictly
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+    return dateRegex.test(dateString) && !isNaN(new Date(dateString).getTime());
+};


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 15-09-2024
<!--Developer Name Here-->
Developer Name: Ayush Sanj

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes #1252 

## Description

<!--Description of the changes made in this PR-->

1. Date picker alignment issue fixed.
2. Loader like `Saving...` updated after saving the task.
3. Moved States to relevant components.
4. Code refactor.
5. Update relevant test cases.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

https://github.com/user-attachments/assets/f619ae91-2cc1-4367-9a22-adfa237335d6

with extension icon:


https://github.com/user-attachments/assets/849b6bd9-8b07-460b-90fb-5ab07a27ba90


with feature dev flag toggle:

https://github.com/user-attachments/assets/9b54fb07-e22b-4110-9b89-351a6411bf36

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>
<!-- Attach your screenshots here👇-->
<img width="822" alt="image" src="https://github.com/user-attachments/assets/215da006-95b3-4bc5-8d06-70df4fd1aec5">

<img width="458" alt="image" src="https://github.com/user-attachments/assets/e29916fa-9162-4e84-bbd6-95c7ac59cdcc">


</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
Found some states in parent component unnecessarily prop drilled which could have been used in details component. so refactored it. To show the input field, I put it in details component to be shown with isEditing + isUserAuthorised. Updated test cases for same. New addition: `Saving...` Loader to show on save while saving task.
