### PR TITLE
Feat: Add shimmer card in tasks page

### DIFF
--- a/__tests__/Unit/pages/Tasks/index.test.tsx
+++ b/__tests__/Unit/pages/Tasks/index.test.tsx
@@ -3,6 +3,7 @@ import Tasks from '@/pages/tasks';
 import { store } from '@/app/store';
 import { Provider } from 'react-redux';
 import { AppTreeType } from 'next/dist/shared/lib/utils';
+import { useGetAllTasksQuery } from '@/app/services/tasksApi';
 
 type TaskPageProps = {
     dev: boolean;
@@ -21,7 +22,47 @@ jest.mock('next/router', () => ({
     }),
 }));
 
+jest.mock('@/app/services/tasksApi', () => ({
+    useGetAllTasksQuery: jest.fn(),
+}));
+
 describe('Tasks', () => {
+    it('should display shimmer cards when isLoading is true and dev is true', () => {
+        (useGetAllTasksQuery as jest.Mock).mockReturnValue({
+            data: { tasks: [], next: '' },
+            isError: false,
+            isLoading: true,
+            isFetching: false,
+        });
+
+        render(
+            <Provider store={store()}>
+                <Tasks dev={true} />
+            </Provider>
+        );
+        const skeletonContainer = screen.getByTestId('task-skeleton-container');
+        expect(skeletonContainer).toBeInTheDocument();
+
+        const shimmerCards = screen.getAllByTestId('task-shimmer-card');
+        expect(shimmerCards).toHaveLength(5);
+    });
+
+    it('should display loading state when isLoading is true', () => {
+        (useGetAllTasksQuery as jest.Mock).mockReturnValue({
+            data: { tasks: [], next: '' },
+            isError: false,
+            isLoading: true,
+            isFetching: false,
+        });
+
+        render(
+            <Provider store={store()}>
+                <Tasks />
+            </Provider>
+        );
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
     it('should render the Tasks component', () => {
         render(
             <Provider store={store()}>

--- a/src/components/tasks/TasksContent.tsx
+++ b/src/components/tasks/TasksContent.tsx
@@ -22,6 +22,7 @@ import {
 
 import useIntersection from '@/hooks/useIntersection';
 import TaskSearchDev from './TaskSearch/TaskSearch';
+import TaskCardShimmer from '../Loaders/taskCardShimmer';
 
 export const TasksContent = ({ dev }: { dev?: boolean }) => {
     const router = useRouter();
@@ -126,6 +127,18 @@ export const TasksContent = ({ dev }: { dev?: boolean }) => {
         onLoadMore: fetchMoreTasks,
         earlyReturn: loadedTasks[selectedTab].length === 0,
     });
+
+    if (isLoading && dev)
+        return (
+            <div
+                className={styles.taskSkeletonContainer}
+                data-testid="task-skeleton-container"
+            >
+                {[...Array(5)].map((n: number, index) => (
+                    <TaskCardShimmer key={index} />
+                ))}
+            </div>
+        );
 
     if (isLoading) return <p>Loading...</p>;
 

--- a/src/styles/tasks.module.scss
+++ b/src/styles/tasks.module.scss
@@ -4,6 +4,17 @@
     width: 64%;
 }
 
+.taskSkeletonContainer {
+    padding: 2rem 0 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    @media (max-width: 448px) {
+        padding: 2rem 1rem 0;
+    }
+}
+
 .container {
     text-align: center;
     display: flex;


### PR DESCRIPTION
Date: 20/12/2024
Developer Name: Vignesh B S

---

## Issue Ticket Number
Closes Real-Dev-Squad/website-status#1288

## Description

- Added shimmer cards to display while tasks are being fetched in dev mode.
- Added test cases to ensure correct rendering of shimmer cards when in dev mode.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [x] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No


<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Desktop UI</summary>

![Screen Recording Dec 20 2024](https://github.com/user-attachments/assets/9bc719d1-2cc8-49ff-a008-775d9c4188eb)

</details>
<details>

<summary>Mobile UI</summary>

![Capture Editor Dec 20 2024](https://github.com/user-attachments/assets/e14389ec-0496-458c-98af-9ee53ae69311)


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![Screenshot 2024-12-20 at 12 04 19 PM](https://github.com/user-attachments/assets/538d3c0a-1f91-4602-a012-1339d4e00cfc)

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
Test case for loading state when dev flag is not passed is also added.