### PR TITLE
HOTFIX(#1388): remove unnecessary dev mode check for self task updates

### DIFF
--- a/src/components/tasks/card/TaskStatusEditMode.tsx
+++ b/src/components/tasks/card/TaskStatusEditMode.tsx
@@ -68,10 +68,9 @@ const TaskStatusEditMode = ({
             payload.percentCompleted = newProgress;
         }
 
-        const taskStatusUpdatePromise =
-            isDevMode && isSelfTask
-                ? updateSelfTask({ id: task.id, task: payload })
-                : updateTask({ id: task.id, task: payload });
+        const taskStatusUpdatePromise = isSelfTask
+            ? updateSelfTask({ id: task.id, task: payload })
+            : updateTask({ id: task.id, task: payload });
 
         setEditedTaskDetails((prev: CardTaskDetails) => ({
             ...prev,


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 18 Jan 2026
<!--Developer Name Here-->
Developer Name: @AnujChhikara 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- #1388 
## Tech Doc Link
<!--Issue ticket this PR closes-->
- NA
## Business Doc Link
<!--Issue ticket this PR closes-->
- NA
## Description
Since My Site has been deprecated, users can now update their tasks only via the Status Site. Requiring a dev flag for task updates is no longer valid behavior. The functionality should work without any environment-specific flags.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

https://github.com/user-attachments/assets/d82cbedd-05ab-4ff3-9458-c73f0c43afc2


<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
